### PR TITLE
Rename classes to indicate 'results' instead of 'reports'

### DIFF
--- a/src/main/java/org/fcrepo/migration/validator/api/ObjectValidationResults.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/ObjectValidationResults.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
  * @author awoods
  * @since 2020-12-17
  */
-public class ObjectValidationReport {
+public class ObjectValidationResults {
 
     /*
      * Validation result which is the subject of this report
@@ -39,7 +39,7 @@ public class ObjectValidationReport {
      * Constructor
      * @param results for the object which is the subject of this report
      */
-    public ObjectValidationReport(final List<ValidationResult> results) {
+    public ObjectValidationResults(final List<ValidationResult> results) {
         this.results = results;
     }
 

--- a/src/main/java/org/fcrepo/migration/validator/api/ReportHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/ReportHandler.java
@@ -31,17 +31,17 @@ public interface ReportHandler {
 
     /**
      * A hook hook for processing an object level validation report
-     * @param objectValidationReport An individual object validation report
+     * @param objectValidationResults An individual object validation report
      * @return filename of object report
      */
-    String objectLevelReport(ObjectValidationReport objectValidationReport);
+    String objectLevelReport(ObjectValidationResults objectValidationResults);
 
     /**
      * A hook for processing a validation run's summary info.
      * @param validationSummary to be processed
      * @return filename of full report
      */
-    String validationSummary(ValidationReportSummary validationSummary);
+    String validationSummary(ValidationResultsSummary validationSummary);
 
     /**
      * A hook indicating the end of a result processing run

--- a/src/main/java/org/fcrepo/migration/validator/api/ValidationResultsSummary.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/ValidationResultsSummary.java
@@ -32,9 +32,9 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @author awoods
  * @since 2020-12-17
  */
-public class ValidationReportSummary {
+public class ValidationResultsSummary {
 
-    private static final Logger LOGGER = getLogger(ValidationReportSummary.class);
+    private static final Logger LOGGER = getLogger(ValidationResultsSummary.class);
 
     // Object-id to report filename map
     private Map<String, String> objectReportFilenames = new HashMap<>();

--- a/src/main/java/org/fcrepo/migration/validator/report/HtmlReportHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/report/HtmlReportHandler.java
@@ -20,9 +20,9 @@ package org.fcrepo.migration.validator.report;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-import org.fcrepo.migration.validator.api.ObjectValidationReport;
+import org.fcrepo.migration.validator.api.ObjectValidationResults;
 import org.fcrepo.migration.validator.api.ReportHandler;
-import org.fcrepo.migration.validator.api.ValidationReportSummary;
+import org.fcrepo.migration.validator.api.ValidationResultsSummary;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -47,7 +47,7 @@ public class HtmlReportHandler implements ReportHandler {
 
     private final File outputDir;
     private final Configuration config;
-    private ValidationReportSummary validationSummary;
+    private ValidationResultsSummary validationSummary;
 
     /**
      * Constructor
@@ -82,12 +82,12 @@ public class HtmlReportHandler implements ReportHandler {
     /**
      * This method write the HTML report for a single object
      *
-     * @param objectValidationReport An individual object validation report
+     * @param objectValidationResults An individual object validation report
      * @return filename of HTML object report
      */
     @Override
-    public String objectLevelReport(final ObjectValidationReport objectValidationReport) {
-        final String id = objectValidationReport.getObjectId();
+    public String objectLevelReport(final ObjectValidationResults objectValidationResults) {
+        final String id = objectValidationResults.getObjectId();
         final String filename = id + ".html";
 
         // Organize data for template
@@ -112,7 +112,7 @@ public class HtmlReportHandler implements ReportHandler {
      * @return filename of full report
      */
     @Override
-    public String validationSummary(final ValidationReportSummary validationSummary) {
+    public String validationSummary(final ValidationResultsSummary validationSummary) {
         final String reportFilename = "index.html";
 
         // Ensure we have a 'validationSummary'

--- a/src/main/java/org/fcrepo/migration/validator/report/ReportGeneratorImpl.java
+++ b/src/main/java/org/fcrepo/migration/validator/report/ReportGeneratorImpl.java
@@ -18,9 +18,9 @@
 package org.fcrepo.migration.validator.report;
 
 import org.apache.commons.io.FilenameUtils;
-import org.fcrepo.migration.validator.api.ObjectValidationReport;
+import org.fcrepo.migration.validator.api.ObjectValidationResults;
 import org.fcrepo.migration.validator.api.ReportHandler;
-import org.fcrepo.migration.validator.api.ValidationReportSummary;
+import org.fcrepo.migration.validator.api.ValidationResultsSummary;
 import org.fcrepo.migration.validator.api.ValidationResult;
 import org.fcrepo.migration.validator.impl.FileSystemValidationResultReader;
 import org.slf4j.Logger;
@@ -52,7 +52,7 @@ public class ReportGeneratorImpl {
 
     private Path resultDir;
     private ReportHandler reportHandler;
-    private ValidationReportSummary summary;
+    private ValidationResultsSummary summary;
 
     /**
      * Constructor
@@ -63,7 +63,7 @@ public class ReportGeneratorImpl {
     public ReportGeneratorImpl(final Path resultDir, final ReportHandler reportHandler) {
         this.resultDir = resultDir;
         this.reportHandler = reportHandler;
-        this.summary = new ValidationReportSummary();
+        this.summary = new ValidationResultsSummary();
     }
 
     /**
@@ -133,6 +133,6 @@ public class ReportGeneratorImpl {
             resultsList.add(reader.read(f));
         }
 
-        return reportHandler.objectLevelReport(new ObjectValidationReport(resultsList));
+        return reportHandler.objectLevelReport(new ObjectValidationResults(resultsList));
     }
 }

--- a/src/main/java/org/fcrepo/migration/validator/report/ResultsReportHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/report/ResultsReportHandler.java
@@ -17,9 +17,9 @@
  */
 package org.fcrepo.migration.validator.report;
 
-import org.fcrepo.migration.validator.api.ObjectValidationReport;
+import org.fcrepo.migration.validator.api.ObjectValidationResults;
 import org.fcrepo.migration.validator.api.ReportHandler;
-import org.fcrepo.migration.validator.api.ValidationReportSummary;
+import org.fcrepo.migration.validator.api.ValidationResultsSummary;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,13 +46,13 @@ public class ResultsReportHandler implements ReportHandler {
     /**
      * A hook hook for processing an object level validation report
      *
-     * @param objectValidationReport An individual object validation report
+     * @param objectValidationResults An individual object validation report
      * @return filename of object report
      */
     @Override
-    public String objectLevelReport(final ObjectValidationReport objectValidationReport) {
-        if (objectValidationReport.hasErrors()) {
-            errors.addAll(objectValidationReport.getErrorDetails());
+    public String objectLevelReport(final ObjectValidationResults objectValidationResults) {
+        if (objectValidationResults.hasErrors()) {
+            errors.addAll(objectValidationResults.getErrorDetails());
         }
 
         // No HTML report filename
@@ -66,7 +66,7 @@ public class ResultsReportHandler implements ReportHandler {
      * @return filename of full report
      */
     @Override
-    public String validationSummary(final ValidationReportSummary validationSummary) {
+    public String validationSummary(final ValidationResultsSummary validationSummary) {
         return null;
     }
 


### PR DESCRIPTION
Resolves: https://github.com/fcrepo-exts/fcrepo-migration-validator/issues/16