### PR TITLE
Remove Spring/Lazy-loading approach

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
         <project_name>${project.artifactId}</project_name>
         <release.plugin.version>2.5.2</release.plugin.version>
         <scm-provider-gitexe.plugin.version>1.9.4</scm-provider-gitexe.plugin.version>
-        <spring.version>5.2.11.RELEASE</spring.version>
         <javadoc.plugin.version>3.2.0</javadoc.plugin.version>
         <source.plugin.version>3.2.0</source.plugin.version>
     </properties>
@@ -242,12 +241,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>
@@ -320,14 +313,6 @@
             <version>2.22.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>5.2.7.RELEASE</version>
-            <scope>test</scope>
-        </dependency>
-
-
     </dependencies>
 
     <distributionManagement>

--- a/src/main/java/org/fcrepo/migration/validator/Driver.java
+++ b/src/main/java/org/fcrepo/migration/validator/Driver.java
@@ -18,12 +18,12 @@
 package org.fcrepo.migration.validator;
 
 import org.fcrepo.migration.validator.impl.F3SourceTypes;
+import org.fcrepo.migration.validator.impl.Fedora3ObjectConfiguration;
 import org.fcrepo.migration.validator.impl.Fedora3ValidationConfig;
 import org.fcrepo.migration.validator.impl.Fedora3ValidationExecutionManager;
 import org.fcrepo.migration.validator.report.HtmlReportHandler;
 import org.fcrepo.migration.validator.report.ReportGeneratorImpl;
 import org.slf4j.Logger;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import picocli.CommandLine;
 
 import java.io.File;
@@ -87,9 +87,8 @@ public class Driver implements Callable<Integer> {
     private boolean debug;
 
     @Override
-    public Integer call() throws Exception {
-        try (final var context = new AnnotationConfigApplicationContext("org.fcrepo.migration.validator")) {
-            final var config = context.getBean(Fedora3ValidationConfig.class);
+    public Integer call() {
+            final var config = new Fedora3ValidationConfig();
             config.setSourceType(f3SourceType);
             config.setDatastreamsDirectory(f3DatastreamsDir);
             config.setObjectsDirectory(f3ObjectsDir);
@@ -100,7 +99,7 @@ public class Driver implements Callable<Integer> {
             LOGGER.info("Configuration created: {}", config);
 
             LOGGER.info("Preparing to execute validation run...");
-            final var executionManager = context.getBean(Fedora3ValidationExecutionManager.class);
+            final var executionManager = new Fedora3ValidationExecutionManager(new Fedora3ObjectConfiguration(config));
             executionManager.doValidation();
 
             final var reportHandler = new HtmlReportHandler(config.getHtmlReportDirectory());
@@ -110,10 +109,6 @@ public class Driver implements Callable<Integer> {
                     "index.html");
 
             return 0;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
     }
 
     /**

--- a/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ObjectConfiguration.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ObjectConfiguration.java
@@ -24,9 +24,6 @@ import org.fcrepo.migration.foxml.InternalIDResolver;
 import org.fcrepo.migration.foxml.LegacyFSIDResolver;
 import org.fcrepo.migration.foxml.NativeFoxmlDirectoryObjectSource;
 import org.fcrepo.migration.validator.api.ValidationResultWriter;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
 
 import java.io.IOException;
 
@@ -38,24 +35,27 @@ import static edu.wisc.library.ocfl.api.util.Enforce.notNull;
  *
  * @author dbernstein
  */
-@Configuration
-@Lazy
 public class Fedora3ObjectConfiguration {
 
-    @Bean
-    public Fedora3ValidationConfig config() {
-        return new Fedora3ValidationConfig();
+    private Fedora3ValidationConfig config;
+
+    public Fedora3ObjectConfiguration(final Fedora3ValidationConfig config) {
+        this.config = config;
     }
 
-    @Bean
-    @Lazy
-    public ValidationResultWriter validationResultWriter(final Fedora3ValidationConfig config) {
+    public ValidationResultWriter validationResultWriter() {
         return new FileSystemValidationResultWriter(config.getJsonOuputDirectory());
     }
 
-    @Bean
-    @Lazy
-    public ObjectSource objectSource(final Fedora3ValidationConfig config) throws IOException {
+    public ObjectSource objectSource() {
+        try {
+            return doObjectSource();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ObjectSource doObjectSource () throws IOException {
         final ObjectSource objectSource;
         final var f3ExportedDir = config.getExportedDirectory();
         final var f3DatastreamsDir = config.getDatastreamsDirectory();
@@ -95,4 +95,7 @@ public class Fedora3ObjectConfiguration {
         return objectSource;
     }
 
+    public int getThreadCount() {
+        return config.getThreadCount();
+    }
 }

--- a/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationExecutionManager.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationExecutionManager.java
@@ -23,9 +23,6 @@ import org.fcrepo.migration.validator.api.ValidationResultWriter;
 import org.fcrepo.migration.validator.api.ValidationTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.stereotype.Component;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -37,8 +34,6 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * @author dbernstein
  */
-@Component
-@Lazy
 public class Fedora3ValidationExecutionManager implements ValidationExecutionManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Fedora3ValidationExecutionManager.class);
@@ -52,14 +47,10 @@ public class Fedora3ValidationExecutionManager implements ValidationExecutionMan
     /**
      * Constructor
      * @param config The config
-     * @param writer The writer
-     * @param source The source
      */
-    public Fedora3ValidationExecutionManager(@Autowired final Fedora3ValidationConfig config,
-                                             @Autowired final ValidationResultWriter writer,
-                                             @Autowired final ObjectSource source) {
-        this.source = source;
-        this.writer = writer;
+    public Fedora3ValidationExecutionManager(final Fedora3ObjectConfiguration config) {
+        this.source = config.objectSource();
+        this.writer = config.validationResultWriter();
         executorService = Executors.newFixedThreadPool(config.getThreadCount());
         this.count = new AtomicLong(0);
         this.lock = new Object();


### PR DESCRIPTION
.. in order to allow for intuitive dependency injection

Since essential configuration is not available until runtime, the contortions of making this a Spring application seem forced.
This became clear when attempting to create multiple integration tests within a single class and observing that the Spring context was requiring a pre-baked configuration... which did not allow for useful dependency injection.