### PR TITLE
Compatibilty update for migration-utils

### DIFF
--- a/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
@@ -138,7 +138,7 @@ public class ApplicationConfigurationHelper {
             final var objectMapper = new ObjectMapper().configure(WRITE_DATES_AS_TIMESTAMPS, false)
                     .registerModule(new JavaTimeModule())
                     .setSerializationInclusion(JsonInclude.Include.NON_NULL);
-            // https://jira.lyrasis.org/browse/FCREPO-3632: 
+            // https://jira.lyrasis.org/browse/FCREPO-3632:
             return new DefaultOcflObjectSessionFactory(repository(config, workDir),
                     workDir,
                     objectMapper,

--- a/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
@@ -160,9 +160,9 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
 
     public void validateDatastream(final String dsId, final ObjectReference objectReference) {
         final var dsVersions = objectReference.getDatastreamVersions(dsId);
-        final var sourceOjbectId = objectInfo.getPid();
+        final var sourceObjectId = objectInfo.getPid();
         final var targetObjectId = this.ocflSession.ocflObjectId();
-        final var sourceResource = sourceOjbectId + "/" + dsId;
+        final var sourceResource = sourceObjectId + "/" + dsId;
         final var targetResource = targetObjectId + "/" + dsId;
         var sourceVersionCount = 0;
         for (final var dsVersion : dsVersions) {
@@ -185,13 +185,13 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
                                 sourceValue, targetValue);
                     }
                     validationResults.add(new ValidationResult(indexCounter++, result, OBJECT_RESOURCE,
-                            BINARY_METADATA, sourceOjbectId, targetObjectId, sourceResource, targetResource, details));
+                            BINARY_METADATA, sourceObjectId, targetObjectId, sourceResource, targetResource, details));
                     validationResults.add(new ValidationResult(indexCounter++, OK, OBJECT_RESOURCE,
-                            SOURCE_OBJECT_RESOURCE_EXISTS_IN_TARGET, sourceOjbectId, targetObjectId, sourceResource,
+                            SOURCE_OBJECT_RESOURCE_EXISTS_IN_TARGET, sourceObjectId, targetObjectId, sourceResource,
                             targetResource, "Source object resource exists in target."));
                 } catch (NotFoundException ex) {
                     validationResults.add(new ValidationResult(indexCounter++, FAIL, OBJECT_RESOURCE,
-                            SOURCE_OBJECT_RESOURCE_EXISTS_IN_TARGET, sourceOjbectId, targetObjectId, sourceResource,
+                            SOURCE_OBJECT_RESOURCE_EXISTS_IN_TARGET, sourceObjectId, targetObjectId, sourceResource,
                             targetResource, "Source object resource does not exist in target."));
 
                 }
@@ -209,7 +209,7 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
                         targetVersionCount);
             }
             validationResults.add(new ValidationResult(indexCounter++, ok ? OK : FAIL, OBJECT_RESOURCE,
-                    BINARY_VERSION_COUNT, sourceOjbectId, targetObjectId, sourceResource, targetResource, details));
+                    BINARY_VERSION_COUNT, sourceObjectId, targetObjectId, sourceResource, targetResource, details));
         } catch (NotFoundException ex) {
             // intentionally left blank: we check for existence above
         }


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3653

The migration-utils were updated and had several classes removed which the validator used which this resolves.

Note: We only need to use the first object from the `Iterable` in the `FedoraObjectVersionHandler#processObjectVersions` as the `ObjectReference` we retrieve is shared across all the objects in the iterable.

* Updates ValidatingObjectHandler to use FedoraObjectVersionHandler
* Minor typo and checkstyle fixes