### PR TITLE
Validation for lastModifiedDate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.19.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.22.0</version>

--- a/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
@@ -29,9 +29,13 @@ import org.junit.Test;
 
 import java.io.File;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.OBJECT;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.BINARY_HEAD_COUNT;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.METADATA;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.SOURCE_OBJECT_EXISTS_IN_TARGET;
+import static org.fcrepo.migration.validator.impl.ValidatingObjectHandler.F3_CREATED_DATE;
+import static org.fcrepo.migration.validator.impl.ValidatingObjectHandler.F3_LAST_MODIFIED_DATE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -60,6 +64,24 @@ public class ObjectValidationIT extends AbstractValidationIT {
 
         // verify expected results
         assertEquals("Should be no errors!", 0, reportHandler.getErrors().size());
+    }
+
+    @Test
+    public void testBadMetadata() {
+        final File f3DatastreamsDir = new File(FIXTURES_BASE_DIR, "valid/f3/datastreams");
+        final File f3ObjectsDir = new File(FIXTURES_BASE_DIR, "bad-metadata/f3/objects");
+        final File f6OcflRootDir = new File(FIXTURES_BASE_DIR, "valid/f6/data/ocfl-root");
+        final ResultsReportHandler reportHandler = doValidation(f3DatastreamsDir, f3ObjectsDir, f6OcflRootDir);
+
+        // verify expected results
+        final var errors = reportHandler.getErrors();
+        assertThat(errors).hasSize(2)
+                          .anyMatch(result -> result.getDetails().contains(F3_CREATED_DATE))
+                          .anyMatch(result -> result.getDetails().contains(F3_LAST_MODIFIED_DATE))
+                          .allSatisfy(result -> {
+                              assertThat(result.getValidationLevel()).isEqualTo(OBJECT);
+                              assertThat(result.getValidationType()).isEqualTo(METADATA);
+                          });
     }
 
     @Test

--- a/src/test/resources/test-object-validation/bad-metadata/f3/objects/dlmap/3/18/c4/info%3Afedora%2F1711.dl%3AUWPAbout
+++ b/src/test/resources/test-object-validation/bad-metadata/f3/objects/dlmap/3/18/c4/info%3Afedora%2F1711.dl%3AUWPAbout
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foxml:digitalObject VERSION="1.1" PID="1711.dl:UWPAbout"
+xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:objectProperties>
+<foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="History of UW–Platteville"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2019-07-01T17:12:45.310Z"/>
+<foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2019-07-25T17:43:56.210Z"/>
+</foxml:objectProperties>
+<foxml:datastream ID="AUDIT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="AUDIT.0" LABEL="Audit Trail for this object" CREATED="2019-07-01T17:12:45.311Z" MIMETYPE="text/xml" FORMAT_URI="info:fedora/fedora-system:format/xml.fedora.audit">
+<foxml:xmlContent>
+<audit:auditTrail xmlns:audit="info:fedora/fedora-system:def/audit#">
+<audit:record ID="AUDREC1">
+<audit:process type="Fedora API-M"/>
+<audit:action>ingest</audit:action>
+<audit:componentID></audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2019-07-01T17:12:45.311Z</audit:date>
+<audit:justification>Ingested from local file ./../DefaultIngestObjects/CollectionObjects/FOXML/UWPAbout.xml</audit:justification>
+</audit:record>
+<audit:record ID="AUDREC2">
+<audit:process type="Fedora API-M"/>
+<audit:action>ingest</audit:action>
+<audit:componentID></audit:componentID>
+<audit:responsibility>fedoraAdmin</audit:responsibility>
+<audit:date>2019-07-25T17:43:56.259Z</audit:date>
+<audit:justification>Ingested from source repository with pid info:fedora/1711.dl:UWPAbout</audit:justification>
+</audit:record>
+</audit:auditTrail>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="RELS-EXT.0" LABEL="RDF Statements about this object" CREATED="2019-07-01T17:12:45.311Z" MIMETYPE="application/rdf+xml" FORMAT_URI="info:fedora/fedora-system:FedoraRELSExt-1.0" SIZE="1031">
+<foxml:contentDigest TYPE="MD5" DIGEST=""/>
+<foxml:xmlContent>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:uwdc="http://digital.library.wisc.edu/1711.dl/rdf/1.0/relations#">
+          <rdf:Description rdf:about="info:fedora/1711.dl:UWPAbout">
+            <hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/1711.dl:CModelUWDCObject"></hasModel>
+            <hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/1711.dl:CModelFirstClassObject"></hasModel>
+            <hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/1711.dl:CModelCollection"></hasModel>
+            <uwdc:hasAccessPolicy rdf:resource="http://digital.library.wisc.edu/1711.dl/Access-policy-open-access-all"></uwdc:hasAccessPolicy>
+          </rdf:Description>
+        </rdf:RDF>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="BIB0" STATE="A" CONTROL_GROUP="M" VERSIONABLE="true">
+<foxml:datastreamVersion ID="BIB0.0" LABEL="MODS Record for this object" CREATED="2019-07-01T17:12:45.311Z" MIMETYPE="text/xml" FORMAT_URI="http://www.loc.gov/mods/v3" SIZE="4049">
+<foxml:contentDigest TYPE="MD5" DIGEST=""/>
+<foxml:contentLocation TYPE="INTERNAL_ID" REF="1711.dl:UWPAbout+BIB0+BIB0.0"/>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="DC.0" LABEL="Dublin Core Record for this object" CREATED="2019-07-01T17:12:45.311Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="395">
+<foxml:contentDigest TYPE="MD5" DIGEST=""/>
+<foxml:xmlContent>
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+xmlns:dc="http://purl.org/dc/elements/1.1/"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>History of UW–Platteville</dc:title>
+  <dc:identifier>1711.dl:UWPAbout</dc:identifier>
+</oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="ADMINMD" STATE="A" CONTROL_GROUP="M" VERSIONABLE="true">
+<foxml:datastreamVersion ID="ADMINMD.0" LABEL="Administrative metadata for this object" CREATED="2019-07-01T17:12:45.311Z" MIMETYPE="text/xml" SIZE="5101">
+<foxml:contentDigest TYPE="MD5" DIGEST=""/>
+<foxml:contentLocation TYPE="INTERNAL_ID" REF="1711.dl:UWPAbout+ADMINMD+ADMINMD.0"/>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="THUMB" STATE="A" CONTROL_GROUP="M" VERSIONABLE="true">
+<foxml:datastreamVersion ID="THUMB.0" LABEL="History of UW–Platteville (thumbnail)" CREATED="2019-07-01T17:12:45.311Z" MIMETYPE="image/jpeg" SIZE="58476">
+<foxml:contentDigest TYPE="MD5" DIGEST=""/>
+<foxml:contentLocation TYPE="INTERNAL_ID" REF="1711.dl:UWPAbout+THUMB+THUMB.0"/>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="REF" STATE="A" CONTROL_GROUP="M" VERSIONABLE="true">
+<foxml:datastreamVersion ID="REF.0" LABEL="History of UW–Platteville (reference)" CREATED="2019-07-01T17:12:45.311Z" MIMETYPE="image/jpeg" SIZE="238194">
+<foxml:contentDigest TYPE="MD5" DIGEST=""/>
+<foxml:contentLocation TYPE="INTERNAL_ID" REF="1711.dl:UWPAbout+REF+REF.0"/>
+</foxml:datastreamVersion>
+</foxml:datastream>
+</foxml:digitalObject>


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3663

* Add PropertyResolver for `lastModifiedDate`
* Add IT test for invalid metadata after migrations

--------------------

## Notes

* For the testing, I only added a single file in the F3 objects dir as it didn't seem necessary to copy all the datastreams/ocfl files over. This had both the `createdDate` and `lastModfiedDate` changed so that the validations will fail. If wanted, we could do the same thing on the OCFL side but it seems redundant to me.
* I moved the `SOURCE_OBJECT_EXISTS...` check as it was duplicated with multiple PropertyResolvers