### PR TITLE
Validation for DatastreamVersion size

### DIFF
--- a/src/main/java/org/fcrepo/migration/validator/impl/F3ControlGroup.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3ControlGroup.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.migration.validator.impl;
+
+/**
+ * Control Groups for Fedora3
+ *
+ * X - Inline XML
+ * M - Managed
+ * E - Externally Referenced
+ * R - Redirect Referenced
+ *
+ * @author mikejritter
+ */
+public enum F3ControlGroup {
+    INLINE_XML, MANAGED, EXTERNALLY_REFERENCED, REDIRECT_REFERENCED;
+
+    public static F3ControlGroup fromString(final String controlGroup) {
+        switch (controlGroup.toUpperCase()) {
+            case "X": return INLINE_XML;
+            case "M": return MANAGED;
+            case "E": return EXTERNALLY_REFERENCED;
+            case "R": return REDIRECT_REFERENCED;
+        }
+
+        throw new IllegalArgumentException(controlGroup + " is not a valid control group identifier!");
+    }
+}

--- a/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
@@ -191,6 +191,9 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
 
                 final var builder = new ValidationResultBuilder(sourceObjectId, targetObjectId, sourceResource,
                                                                 targetResource, OBJECT_RESOURCE);
+                final var createdResult = validateCreatedDate(sourceCreated, headers, version, builder);
+                validationResults.add(createdResult);
+                validationResults.add(validateSize(dsVersion, headers, version, builder));
 
                 validationResults.add(validateCreatedDate(sourceCreated, headers, version, builder));
                 validationResults.add(validateLastModified(dsVersion, headers, version, builder));
@@ -248,6 +251,20 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
             return builder.build(BINARY_METADATA, OK, format(success, version, sourceCreated));
         } else {
             return builder.build(BINARY_METADATA, FAIL, format(error, version, sourceCreated, targetCreated));
+        }
+    }
+
+    private ValidationResult validateSize(final DatastreamVersion dsVersion, final ResourceHeaders headers,
+                                          final String version, final ValidationResultBuilder builder) {
+        final var error = "%s binary size does not match: sourceValue=%s, targetValue=%s";
+        final var success = "%s binary size matches: %s";
+
+        final var sourceSize = dsVersion.getSize();
+        final var targetSize = headers.getContentSize();
+        if (sourceSize == targetSize) {
+            return builder.build(BINARY_METADATA, OK, format(success, version, sourceSize));
+        } else {
+            return builder.build(BINARY_METADATA, FAIL, format(error, version, sourceSize, targetSize));
         }
     }
 

--- a/src/test/java/org/fcrepo/migration/validator/AbstractValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/AbstractValidationIT.java
@@ -19,6 +19,7 @@ package org.fcrepo.migration.validator;
 
 import java.io.File;
 
+import org.fcrepo.migration.validator.api.ValidationResult;
 import org.fcrepo.migration.validator.impl.ApplicationConfigurationHelper;
 import org.fcrepo.migration.validator.impl.F3SourceTypes;
 import org.fcrepo.migration.validator.impl.Fedora3ValidationConfig;
@@ -66,6 +67,31 @@ public abstract class AbstractValidationIT {
         config.setResultsDirectory(RESULTS_DIR.toPath());
 
         return config;
+    }
+
+    /**
+     * Quick enum to help check the type of validations run. So instead of running result.getDetails.contains(...),
+     * create an enum type based on the details for (hopefully) cleaner assertions.
+     */
+    public enum BinaryMetadataValidation {
+        CREATION_DATE, LAST_MODIFIED_DATE, SIZE;
+
+        public static BinaryMetadataValidation fromResult(final ValidationResult result) {
+            if (result.getValidationType() != ValidationResult.ValidationType.BINARY_METADATA) {
+                throw new IllegalArgumentException("Enum type is only for BINARY_METADATA!");
+            }
+
+            final var details = result.getDetails();
+            if (details.contains("last modified date")) {
+                return LAST_MODIFIED_DATE;
+            } else if (details.contains("creation date")) {
+                return CREATION_DATE;
+            } else if (details.contains("size")) {
+                return SIZE;
+            }
+
+            throw new IllegalArgumentException("Unknown details type!");
+        }
     }
 
 }


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3664

* Add validation method for Datastream size
* Create enum type for Fedora3 Datastream ControlGroup
* Create enum type for helping derive the type of `BINARY_METADATA` validation in tests
* Add checks for Datastream size validations in tests

-----------------

### Notes

I ended up changing the `ValidationResultBuilder` a bit as the lines were exceeding 120 characters. Not really something necessary, just for convenience.

Likewise when implementing `validateSize`, it felt appropriate to have the logic handling the control group check in the method which resulted in adding the `ValidationResult` in the method rather than returning it. To keep things consistent, I updated `validateCreateDate` and `validateLastModified` to follow this as well. I'm still not sure how I feel about it but it's pretty minor.