### PR TITLE
Validate repository object count

### DIFF
--- a/src/main/java/org/fcrepo/migration/validator/Driver.java
+++ b/src/main/java/org/fcrepo/migration/validator/Driver.java
@@ -103,7 +103,7 @@ public class Driver implements Callable<Integer> {
                                       "${COMPLETION-CANDIDATES}")
     private F6DigestAlgorithm algorithm;
 
-    @CommandLine.Option(names = {"--check-num-objects"}, order = 17,
+    @CommandLine.Option(names = {"--check-num-objects", "-n"}, order = 17,
                         description = "Enable validation comparing the number of objects in the Fedora 3 and Fedora " +
                                       "OCFL repositories. This validation is always disabled if a PID File is used.")
     private boolean checkNumberOfObjects;

--- a/src/main/java/org/fcrepo/migration/validator/Driver.java
+++ b/src/main/java/org/fcrepo/migration/validator/Driver.java
@@ -103,6 +103,11 @@ public class Driver implements Callable<Integer> {
                                       "${COMPLETION-CANDIDATES}")
     private F6DigestAlgorithm algorithm;
 
+    @CommandLine.Option(names = {"--check-num-objects"}, order = 17,
+                        description = "Enable validation comparing the number of objects in the Fedora 3 and Fedora " +
+                                      "OCFL repositories. This validation is always disabled if a PID File is used.")
+    private boolean checkNumberOfObjects;
+
     @CommandLine.Option(names = {"--debug"}, order = 30, description = "Enables debug logging")
     private boolean debug;
 
@@ -111,6 +116,7 @@ public class Driver implements Callable<Integer> {
         final var config = new Fedora3ValidationConfig();
         config.setSourceType(f3SourceType);
         config.setEnableChecksums(checksum);
+        config.setCheckNumObjects(checkNumberOfObjects);
         config.setDigestAlgorithm(algorithm);
         config.setDatastreamsDirectory(f3DatastreamsDir);
         config.setObjectsDirectory(f3ObjectsDir);

--- a/src/main/java/org/fcrepo/migration/validator/api/ReportHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/ReportHandler.java
@@ -30,11 +30,19 @@ public interface ReportHandler {
     void beginReport();
 
     /**
-     * A hook hook for processing an object level validation report
+     * A hook for processing an object level validation report
      * @param objectValidationResults An individual object validation report
      * @return filename of object report
      */
     String objectLevelReport(ObjectValidationResults objectValidationResults);
+
+    /**
+     * A hook for processing a repository level validation report
+     *
+     * @param objectValidationResults An individual validation report
+     * @return filename of repository report
+     */
+    String repositoryLevelReport(ObjectValidationResults objectValidationResults);
 
     /**
      * A hook for processing a validation run's summary info.

--- a/src/main/java/org/fcrepo/migration/validator/api/RepositoryValidator.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/RepositoryValidator.java
@@ -17,11 +17,12 @@
  */
 package org.fcrepo.migration.validator.api;
 
+import edu.wisc.library.ocfl.api.OcflRepository;
+
 /**
  * An interface for performing validations across the repository.
  *
  * @author dbernstein
  */
-public interface RepositoryValidator extends Validator {
-
+public interface RepositoryValidator extends Validator<OcflRepository> {
 }

--- a/src/main/java/org/fcrepo/migration/validator/api/ValidationResultsSummary.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/ValidationResultsSummary.java
@@ -38,6 +38,7 @@ public class ValidationResultsSummary {
 
     // Object-id to report filename map
     private final Map<String, ObjectReportSummary> objectReports = new HashMap<>();
+    private ObjectReportSummary repositoryReport;
 
     /**
      * Setter for collecting ObjectReport filenames
@@ -63,5 +64,17 @@ public class ValidationResultsSummary {
      */
     public Collection<ObjectReportSummary> getObjectReports() {
         return objectReports.values();
+    }
+
+    /**
+     * Setter for the repository level ObjectReportSummary
+     * @param repositoryReport the report
+     */
+    public void addRepositoryReport(final ObjectReportSummary repositoryReport) {
+        this.repositoryReport = repositoryReport;
+    }
+
+    public ObjectReportSummary getRepositoryReport() {
+        return repositoryReport;
     }
 }

--- a/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidationTask.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidationTask.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.migration.validator.impl;
+
+import edu.wisc.library.ocfl.api.OcflRepository;
+import org.fcrepo.migration.validator.api.ValidationResultWriter;
+import org.fcrepo.migration.validator.api.ValidationTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class just starts a {@link F3RepositoryValidator} and writes the output to a file
+ *
+ * @author mikejritter
+ */
+public class F3RepositoryValidationTask extends ValidationTask {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(F3RepositoryValidationTask.class);
+
+    private final long numObjects;
+    private final boolean checkNumObjects;
+    private final OcflRepository ocflRepository;
+    private final ValidationResultWriter writer;
+
+    /**
+     * Constructor
+     *
+     * @param checkNumObjects
+     * @param ocflRepository
+     * @param writer
+     */
+    public F3RepositoryValidationTask(final boolean checkNumObjects,
+                                      final long numObjects,
+                                      final OcflRepository ocflRepository,
+                                      final ValidationResultWriter writer) {
+        this.writer = writer;
+        this.numObjects = numObjects;
+        this.ocflRepository = ocflRepository;
+        this.checkNumObjects = checkNumObjects;
+    }
+
+    @Override
+    public void run() {
+        LOGGER.info("starting repository processor");
+        final var repositoryValidator = new F3RepositoryValidator(checkNumObjects, numObjects);
+        final var results = repositoryValidator.validate(ocflRepository);
+        writer.write(results);
+    }
+}

--- a/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidationTask.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidationTask.java
@@ -41,6 +41,7 @@ public class F3RepositoryValidationTask extends ValidationTask {
      * Constructor
      *
      * @param checkNumObjects
+     * @param numObjects
      * @param ocflRepository
      * @param writer
      */

--- a/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidator.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidator.java
@@ -30,6 +30,11 @@ import org.fcrepo.migration.validator.api.ValidationResult.Status;
 import org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel;
 import org.fcrepo.migration.validator.api.ValidationResult.ValidationType;
 
+/**
+ * A validator for repository scoped validations for F3 against F6
+ *
+ * @author mikejritter
+ */
 public class F3RepositoryValidator implements RepositoryValidator {
 
     private final boolean enableCheckNumObjects;
@@ -38,7 +43,7 @@ public class F3RepositoryValidator implements RepositoryValidator {
     private final List<ValidationResult> validationResults = new ArrayList<>();
 
     /**
-     * Construct
+     * Constructor
      *
      * @param enableCheckNumObjects
      * @param numObjects
@@ -65,7 +70,7 @@ public class F3RepositoryValidator implements RepositoryValidator {
         try (final var ocflIds = ocflRepository.listObjectIds()) {
             final long ocflCount = ocflIds.count();
 
-            ValidationResult result;
+            final ValidationResult result;
             if (ocflCount == numObjectsF3) {
                 result = new ValidationResult(index.getAndIncrement(), Status.OK, ValidationLevel.REPOSITORY,
                                               ValidationType.REPOSITORY_RESOURCE_COUNT, format(success, numObjectsF3));

--- a/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidator.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidator.java
@@ -75,7 +75,7 @@ public class F3RepositoryValidator implements RepositoryValidator {
                 result = new ValidationResult(index.getAndIncrement(), Status.OK, ValidationLevel.REPOSITORY,
                                               ValidationType.REPOSITORY_RESOURCE_COUNT, format(success, numObjectsF3));
             } else {
-                result = new ValidationResult(index.getAndIncrement(), Status.OK, ValidationLevel.REPOSITORY,
+                result = new ValidationResult(index.getAndIncrement(), Status.FAIL, ValidationLevel.REPOSITORY,
                                               ValidationType.REPOSITORY_RESOURCE_COUNT,
                                               format(error, numObjectsF3, ocflCount));
             }

--- a/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidator.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidator.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.migration.validator.impl;
+
+import static java.lang.String.format;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import edu.wisc.library.ocfl.api.OcflRepository;
+import org.fcrepo.migration.validator.api.RepositoryValidator;
+import org.fcrepo.migration.validator.api.ValidationResult;
+import org.fcrepo.migration.validator.api.ValidationResult.Status;
+import org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel;
+import org.fcrepo.migration.validator.api.ValidationResult.ValidationType;
+
+public class F3RepositoryValidator implements RepositoryValidator {
+
+    private final boolean enableCheckNumObjects;
+    private final AtomicInteger index;
+    private final long numObjectsF3;
+    private final List<ValidationResult> validationResults = new ArrayList<>();
+
+    /**
+     * Construct
+     *
+     * @param enableCheckNumObjects
+     * @param numObjects
+     */
+    public F3RepositoryValidator(final boolean enableCheckNumObjects, final long numObjects) {
+        this.numObjectsF3 = numObjects;
+        this.index = new AtomicInteger(0);
+        this.enableCheckNumObjects = enableCheckNumObjects;
+    }
+
+    @Override
+    public List<ValidationResult> validate(final OcflRepository repository) {
+        if (enableCheckNumObjects) {
+            checkObjects(repository);
+        }
+
+        return validationResults;
+    }
+
+    private void checkObjects(final OcflRepository ocflRepository) {
+        final var success = "Repository object counts match: Total=%s";
+        final var error = "Repository object counts do not match: sourceValue=%s, targetValue=%s";
+
+        try (final var ocflIds = ocflRepository.listObjectIds()) {
+            final long ocflCount = ocflIds.count();
+
+            ValidationResult result;
+            if (ocflCount == numObjectsF3) {
+                result = new ValidationResult(index.getAndIncrement(), Status.OK, ValidationLevel.REPOSITORY,
+                                              ValidationType.REPOSITORY_RESOURCE_COUNT, format(success, numObjectsF3));
+            } else {
+                result = new ValidationResult(index.getAndIncrement(), Status.OK, ValidationLevel.REPOSITORY,
+                                              ValidationType.REPOSITORY_RESOURCE_COUNT,
+                                              format(error, numObjectsF3, ocflCount));
+            }
+
+            validationResults.add(result);
+        }
+    }
+
+}

--- a/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationConfig.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationConfig.java
@@ -29,6 +29,7 @@ import java.io.File;
 public class Fedora3ValidationConfig extends ValidationConfig {
 
     private boolean checksum;
+    private boolean checkNumObjects;
     private F6DigestAlgorithm digestAlgorithm;
     private F3SourceTypes sourceType;
     private File exportedDirectory;
@@ -155,5 +156,17 @@ public class Fedora3ValidationConfig extends ValidationConfig {
 
     public F6DigestAlgorithm getDigestAlgorithm() {
         return digestAlgorithm;
+    }
+
+    public boolean checkNumObjects() {
+        return checkNumObjects;
+    }
+
+    /**
+     * @param checkNumObjects
+     */
+    public Fedora3ValidationConfig setCheckNumObjects(final boolean checkNumObjects) {
+        this.checkNumObjects = checkNumObjects;
+        return this;
     }
 }

--- a/src/main/java/org/fcrepo/migration/validator/report/CsvReportHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/report/CsvReportHandler.java
@@ -108,6 +108,12 @@ public class CsvReportHandler implements ReportHandler {
     }
 
     @Override
+    public String repositoryLevelReport(final ObjectValidationResults objectValidationResults) {
+        // just use the previous implementation for now; can update later if needed
+        return objectLevelReport(objectValidationResults);
+    }
+
+    @Override
     public void endReport() {
         // no-op
     }

--- a/src/main/java/org/fcrepo/migration/validator/report/HtmlReportHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/report/HtmlReportHandler.java
@@ -115,6 +115,23 @@ public class HtmlReportHandler implements ReportHandler {
         return filename;
     }
 
+    @Override
+    public String repositoryLevelReport(final ObjectValidationResults objectValidationResults) {
+        final String filename = "repository.html";
+
+        try {
+            final Template template = config.getTemplate("repository.ftl");
+            final var file = new File(outputDir, filename);
+            file.getParentFile().mkdirs();
+            final Writer writer = new FileWriter(file);
+            template.process(null, writer);
+        } catch (final IOException | TemplateException e) {
+            throw new RuntimeException(e);
+        }
+
+        return filename;
+    }
+
     /**
      * This method writes the HTML summary of the entire validation run
      *

--- a/src/main/java/org/fcrepo/migration/validator/report/ResultsReportHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/report/ResultsReportHandler.java
@@ -60,6 +60,15 @@ public class ResultsReportHandler implements ReportHandler {
         return null;
     }
 
+    @Override
+    public String repositoryLevelReport(final ObjectValidationResults objectValidationResults) {
+        errors.addAll(objectValidationResults.getErrors());
+        passed.addAll(objectValidationResults.getPassed());
+
+        // No HTML report filename
+        return null;
+    }
+
     /**
      * A hook for processing a validation run's summary info.
      *

--- a/src/main/resources/templates/repository.ftl
+++ b/src/main/resources/templates/repository.ftl
@@ -1,0 +1,45 @@
+<html>
+<head>
+    <title>Repository Report</title>
+    <style>
+  html {
+    font-family: sans-serif;
+  }
+
+  body {
+    margin: 0;
+    font-family: var(--bs-font-sans-serif);
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+  }
+
+  header {
+    width: 100%;
+    height: 64px;
+    line-height: 64px;
+    text-align: center;
+    border-bottom: solid 1px;
+  }
+
+  header h1 {
+    font-size: 2rem;
+    padding: 0;
+    margin: auto;
+  }
+
+  .linkback {
+    text-decoration: none;
+    font-size: 1.2rem;
+    padding: 0 15px;
+    float: left;
+  }
+  </style>
+</head>
+<body>
+<header>
+    <a class="linkback" href="index.html">To Summary</a>
+    <h1>Repository Validation Results</h1>
+</header>
+</body>
+</html>

--- a/src/test/java/org/fcrepo/migration/validator/RepoValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/RepoValidationIT.java
@@ -18,18 +18,12 @@
 package org.fcrepo.migration.validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.fcrepo.migration.validator.AbstractValidationIT.BinaryMetadataValidation.CREATION_DATE;
-import static org.fcrepo.migration.validator.AbstractValidationIT.BinaryMetadataValidation.LAST_MODIFIED_DATE;
-import static org.fcrepo.migration.validator.AbstractValidationIT.BinaryMetadataValidation.SIZE;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.REPOSITORY;
-import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.BINARY_METADATA;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.REPOSITORY_RESOURCE_COUNT;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
-import java.util.stream.Collectors;
 
-import org.fcrepo.migration.validator.api.ValidationResult;
 import org.fcrepo.migration.validator.impl.ApplicationConfigurationHelper;
 import org.fcrepo.migration.validator.impl.Fedora3ValidationConfig;
 import org.fcrepo.migration.validator.impl.Fedora3ValidationExecutionManager;

--- a/src/test/java/org/fcrepo/migration/validator/RepoValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/RepoValidationIT.java
@@ -17,6 +17,24 @@
  */
 package org.fcrepo.migration.validator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.fcrepo.migration.validator.AbstractValidationIT.BinaryMetadataValidation.CREATION_DATE;
+import static org.fcrepo.migration.validator.AbstractValidationIT.BinaryMetadataValidation.LAST_MODIFIED_DATE;
+import static org.fcrepo.migration.validator.AbstractValidationIT.BinaryMetadataValidation.SIZE;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.REPOSITORY;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.BINARY_METADATA;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.REPOSITORY_RESOURCE_COUNT;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.stream.Collectors;
+
+import org.fcrepo.migration.validator.api.ValidationResult;
+import org.fcrepo.migration.validator.impl.ApplicationConfigurationHelper;
+import org.fcrepo.migration.validator.impl.Fedora3ValidationConfig;
+import org.fcrepo.migration.validator.impl.Fedora3ValidationExecutionManager;
+import org.fcrepo.migration.validator.report.ReportGeneratorImpl;
+import org.fcrepo.migration.validator.report.ResultsReportHandler;
 import org.junit.Test;
 
 /**
@@ -27,8 +45,34 @@ public class RepoValidationIT extends AbstractValidationIT {
 
     @Test
     public void test() {
+        final File f3DatastreamsDir = new File(FIXTURES_BASE_DIR, "valid/f3/datastreams");
+        final File f3ObjectsDir = new File(FIXTURES_BASE_DIR, "valid/f3/objects");
+        final File f6OcflRootDir = new File(FIXTURES_BASE_DIR, "valid/f6/data/ocfl-root");
+        final ResultsReportHandler reportHandler = doValidation(f3DatastreamsDir, f3ObjectsDir, f6OcflRootDir);
 
+        // verify expected results
+        assertEquals("Should be no errors!", 0, reportHandler.getErrors().size());
+
+        // check that the repository validations were run
+        assertThat(reportHandler.getPassed())
+            .anyMatch(result -> result.getValidationType() == REPOSITORY_RESOURCE_COUNT)
+            .anyMatch(result -> result.getValidationLevel() == REPOSITORY);
     }
 
+    @Override
+    public ResultsReportHandler doValidation(final File f3DatastreamsDir,
+                                             final File f3ObjectsDir,
+                                             final File f6OcflRootDir) {
+        final Fedora3ValidationConfig config = getConfig(f3DatastreamsDir, f3ObjectsDir, f6OcflRootDir);
+        config.setCheckNumObjects(true);
+        final var configuration = new ApplicationConfigurationHelper(config);
+        final var executionManager = new Fedora3ValidationExecutionManager(configuration);
+        executionManager.doValidation();
 
+        // run report generator with 'ResultsReportHandler'
+        final ResultsReportHandler reportHandler = new ResultsReportHandler();
+        final var generator = new ReportGeneratorImpl(config.getJsonOutputDirectory(), reportHandler);
+        generator.generate();
+        return reportHandler;
+    }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3682

# What does this Pull Request do?
Adds a validation to check that the F3 object count is equal to the F6 OCFL object count

# What's new?
* Add validate for repository level validations
* Add hooks to handle repository level reports for the ReportHandlers and ValidationResultsSummary
* Add cli option for enabling the number of objects check
* Allows the OcflRepository to be used by validators if needed
* Adds empty freemarker template for repository reports
* Uses object level csv report for the repository level

# How should this be tested?

* Run the migration validator using the `csv` and `--check-num-objects` options:
```
java -jar target/fcrepo-migration-validator-0.1.0-SNAPSHOT-driver.jar -s akubra -d /path/to/datastreams/ -o /path/to/objects -r /path/to/validation-output -c /path/to/fcrepo-data/data/ocfl-root --report-type csv --check-num-objects 
```
* Check the output of `repository.csv` and/or the `json/results-0.json`