### PR TITLE
Add ownerId validation for object metadata

### DIFF
--- a/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
@@ -71,6 +71,7 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
 
     public static final String F3_CREATED_DATE = "info:fedora/fedora-system:def/model#createdDate";
     public static final String F3_LAST_MODIFIED_DATE = "info:fedora/fedora-system:def/view#lastModifiedDate";
+    public static final String F3_OWNER_ID = "info:fedora/fedora-system:def/model#ownerId";
 
     private ObjectInfo objectInfo;
     private final boolean checksum;
@@ -86,6 +87,7 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
     static {
         OCFL_PROPERTY_RESOLVERS.put(F3_CREATED_DATE, headers -> headers.getCreatedDate().toString());
         OCFL_PROPERTY_RESOLVERS.put(F3_LAST_MODIFIED_DATE, headers -> headers.getLastModifiedDate().toString());
+        OCFL_PROPERTY_RESOLVERS.put(F3_OWNER_ID, headers -> headers.getCreatedBy());
     }
 
     private interface PropertyResolver<T> {

--- a/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
@@ -98,6 +98,10 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
         T resolve(ResourceHeaders headers);
     }
 
+    private interface Resolver<T, R> {
+        T resolve(R r);
+    }
+
     @Override
     public void processObjectVersions(final Iterable<ObjectVersionReference> iterable, final ObjectInfo objectInfo) {
         this.objectInfo = objectInfo;
@@ -179,10 +183,10 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
                 final var result = sourceValue.equals(targetValue) ? OK : FAIL;
                 if (result.equals(FAIL)) {
                     details = format("pid: %s -> properties do not match: f3 prop name=%s, source=%s, target=%s",
-                                     property, pid, sourceValue, targetValue);
+                                     pid, property, sourceValue, targetValue);
                 } else {
                     details = format("pid: %s -> props match: f3 prop name=%s, source=%s, target=%s",
-                                     property, pid, sourceValue, targetValue);
+                                     pid, property, sourceValue, targetValue);
                 }
                 LOGGER.info("PID = {}, object property: name = {}, value = {}", pid, property, sourceValue);
                 validationResults.add(new ValidationResult(indexCounter++, result, OBJECT, METADATA,

--- a/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
@@ -179,6 +179,7 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
             final var error = "pid: %s -> properties do not match: f3 prop name=%s, source=%s, target=%s";
 
             findOcflValue(ocflId, property, model, headers).map(targetValue -> {
+                LOGGER.info("PID = {}, object property: name = {}, value = {}", pid, property, sourceValue);
                 if (sourceValue.equals(targetValue)) {
                     return builder.ok(METADATA, format(success, pid, property, sourceValue, targetValue));
                 }

--- a/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
@@ -148,11 +148,10 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
      * @return true if initial validation successful and should proceed.
      */
     private boolean initialObjectValidation(final ObjectProperties objectProperties) {
+        final ResourceHeaders headers;
         final var pid = objectInfo.getPid();
         final var ocflId = ocflSession.ocflObjectId();
-
-        final ResourceHeaders headers;
-        final Model model = ModelFactory.createDefaultModel();
+        final var model = ModelFactory.createDefaultModel();
 
         try {
             headers = ocflSession.readHeaders(ocflId);
@@ -173,7 +172,7 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
         // check properties against what is stored in OCFL
         final var builder = new ValidationResultBuilder(pid, ocflId, null, null, OBJECT);
         objectProperties.listProperties().forEach(op -> {
-            final String property = op.getName();
+            final var property = op.getName();
             final var sourceValue = op.getValue();
             final var success = "pid: %s -> properties match: f3 prop name=%s, source=%s, target=%s";
             final var error = "pid: %s -> properties do not match: f3 prop name=%s, source=%s, target=%s";

--- a/src/main/resources/templates/object.ftl
+++ b/src/main/resources/templates/object.ftl
@@ -134,8 +134,8 @@
             <td>${error.validationLevel}</td>
             <td>${error.validationType}</td>
             <td>${error.details}</td>
-            <td>${error.sourceObjectId}</td>
-            <td>${error.targetObjectId}</td>
+            <td>${error.sourceObjectId!'dne'}</td>
+            <td>${error.targetObjectId!'dne'}</td>
             <td>${error.sourceResourceId!'dne'}</td>
             <td>${error.targetResourceId!'dne'}</td>
           </tr>
@@ -170,8 +170,8 @@
             <td>${s.validationLevel}</td>
             <td>${s.validationType}</td>
             <td>${s.details}</td>
-            <td>${s.sourceObjectId}</td>
-            <td>${s.targetObjectId}</td>
+            <td>${s.sourceObjectId!'dne'}</td>
+            <td>${s.targetObjectId!'dne'}</td>
             <td>${s.sourceResourceId!'dne'}</td>
             <td>${s.targetResourceId!'dne'}</td>
           </tr>

--- a/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
@@ -87,7 +87,8 @@ public class ObjectValidationIT extends AbstractValidationIT {
 
         // verify expected results
         final var errors = reportHandler.getErrors();
-        assertThat(errors).hasSize(2)
+        assertThat(errors).hasSize(3)
+                          .anyMatch(result -> result.getDetails().contains(F3_OWNER_ID))
                           .anyMatch(result -> result.getDetails().contains(F3_CREATED_DATE))
                           .anyMatch(result -> result.getDetails().contains(F3_LAST_MODIFIED_DATE))
                           .allSatisfy(result -> {

--- a/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.migration.validator;
 
+import org.fcrepo.migration.validator.api.ValidationResult;
 import org.fcrepo.migration.validator.report.ResultsReportHandler;
 import org.junit.Test;
 
@@ -34,6 +35,7 @@ import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.SOURCE_OBJECT_EXISTS_IN_TARGET;
 import static org.fcrepo.migration.validator.impl.ValidatingObjectHandler.F3_CREATED_DATE;
 import static org.fcrepo.migration.validator.impl.ValidatingObjectHandler.F3_LAST_MODIFIED_DATE;
+import static org.fcrepo.migration.validator.impl.ValidatingObjectHandler.F3_OWNER_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -54,19 +56,26 @@ public class ObjectValidationIT extends AbstractValidationIT {
 
         // verify expected results
         assertEquals("Should be no errors!", 0, reportHandler.getErrors().size());
+        final var resultsByType = reportHandler.getPassed().stream()
+                                               .collect(Collectors.groupingBy(ValidationResult::getValidationType));
+
+        // check that we have results for each of the f3 properties we look for
+        final var metadataResults = resultsByType.get(METADATA);
+        assertThat(metadataResults).anyMatch(result -> result.getDetails().contains(F3_OWNER_ID))
+                                   .anyMatch(result -> result.getDetails().contains(F3_CREATED_DATE))
+                                   .anyMatch(result -> result.getDetails().contains(F3_LAST_MODIFIED_DATE));
 
         // check datastream metadata
         // we have 7 datastreams overall -- 4 files and 3 inline
         final var totalManaged = 4;
         final var totalDatastreams = 7;
-        final var passed = reportHandler.getPassed().stream()
-                                        .filter(result -> result.getValidationType() == BINARY_METADATA)
-                                        .map(BinaryMetadataValidation::fromResult)
-                                        .collect(Collectors.toList());
-        assertThat(passed).containsOnly(CREATION_DATE, LAST_MODIFIED_DATE, SIZE);
-        assertThat(passed).filteredOn(validation -> validation == SIZE).hasSize(totalManaged);
-        assertThat(passed).filteredOn(validation -> validation == CREATION_DATE).hasSize(totalDatastreams);
-        assertThat(passed).filteredOn(validation -> validation == LAST_MODIFIED_DATE).hasSize(totalDatastreams);
+        final var binaryMetadata = resultsByType.get(BINARY_METADATA).stream()
+                                                .map(BinaryMetadataValidation::fromResult)
+                                                .collect(Collectors.toList());
+        assertThat(binaryMetadata).containsOnly(CREATION_DATE, LAST_MODIFIED_DATE, SIZE);
+        assertThat(binaryMetadata).filteredOn(validation -> validation == SIZE).hasSize(totalManaged);
+        assertThat(binaryMetadata).filteredOn(validation -> validation == CREATION_DATE).hasSize(totalDatastreams);
+        assertThat(binaryMetadata).filteredOn(validation -> validation == LAST_MODIFIED_DATE).hasSize(totalDatastreams);
     }
 
     @Test

--- a/src/test/resources/test-object-validation/bad-metadata/f3/objects/dlmap/3/18/c4/info%3Afedora%2F1711.dl%3AUWPAbout
+++ b/src/test/resources/test-object-validation/bad-metadata/f3/objects/dlmap/3/18/c4/info%3Afedora%2F1711.dl%3AUWPAbout
@@ -6,7 +6,7 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
 <foxml:objectProperties>
 <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
 <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="History of UW–Platteville"/>
-<foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="exampleOwner"/>
 <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2019-07-01T17:12:45.310Z"/>
 <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2019-07-25T17:43:56.210Z"/>
 </foxml:objectProperties>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3683

# What does this Pull Request do?

Adds validation for `ownerId` in the object metadata

# What's new?

* Checks the ownerId in the foxml against the value stored in fcr-container.nt for ocfl
* Added additional Set to control metadata we want to check for
* Move logic for resolving F6 property values to `findOcflValue`
* Add checks for object metadata to ObjectValidationIT

# How should this be tested?

* Run the validator and check for existence of validation with the `ownerId`

# Additional Notes:

* I wanted to add some integration tests which handle errors in the object metadata, but haven't added any fixture data for those cases yet
  * This would be to test the behavior the resolvers have when metadata is missing from the files (like if the fcr-container.nt is missing the triple)

# Interested parties

@dbernstein 