### PR TITLE
Add option for validating head datastreams only

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Usage: fcrepo-migration-validator [-ChV] [--debug] [-a=<algorithm>]
                    The digest algorithm to use during checksum validation:
                      sha256, sha512
                      Default: sha512
+  -n, --check-num-objects   Enable validation comparing the number of objects
+                              in the Fedora 3 and Fedora OCFL repositories.
+                              This validation is always disabled if a PID File
+                              is used.
+  -H, --head-only           Validate only the most recent version of a
+                              datastream
   --debug      Enables debug logging
 ```
 

--- a/src/main/java/org/fcrepo/migration/validator/Driver.java
+++ b/src/main/java/org/fcrepo/migration/validator/Driver.java
@@ -103,7 +103,7 @@ public class Driver implements Callable<Integer> {
                                       "${COMPLETION-CANDIDATES}")
     private F6DigestAlgorithm algorithm;
 
-    @CommandLine.Option(names = {"--head-only", "-H"}, order=18,
+    @CommandLine.Option(names = {"--head-only", "-H"}, order = 18,
                         description = "Validate only the most recent version of a datastream")
     private boolean validateHeadOnly;
 

--- a/src/main/java/org/fcrepo/migration/validator/Driver.java
+++ b/src/main/java/org/fcrepo/migration/validator/Driver.java
@@ -103,6 +103,10 @@ public class Driver implements Callable<Integer> {
                                       "${COMPLETION-CANDIDATES}")
     private F6DigestAlgorithm algorithm;
 
+    @CommandLine.Option(names = {"--head-only", "-H"}, order=18,
+                        description = "Validate only the most recent version of a datastream")
+    private boolean validateHeadOnly;
+
     @CommandLine.Option(names = {"--check-num-objects", "-n"}, order = 17,
                         description = "Enable validation comparing the number of objects in the Fedora 3 and Fedora " +
                                       "OCFL repositories. This validation is always disabled if a PID File is used.")
@@ -117,6 +121,7 @@ public class Driver implements Callable<Integer> {
         config.setSourceType(f3SourceType);
         config.setEnableChecksums(checksum);
         config.setCheckNumObjects(checkNumberOfObjects);
+        config.setValidateHeadOnly(validateHeadOnly);
         config.setDigestAlgorithm(algorithm);
         config.setDatastreamsDirectory(f3DatastreamsDir);
         config.setObjectsDirectory(f3ObjectsDir);

--- a/src/main/java/org/fcrepo/migration/validator/api/ObjectValidationConfig.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/ObjectValidationConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.migration.validator.api;
+
+import org.fcrepo.migration.validator.impl.F6DigestAlgorithm;
+
+/**
+ * Hold some configuration options for validation objects
+ *
+ * @author mikejritter
+ */
+public class ObjectValidationConfig {
+
+    private final boolean checksum;
+    private final boolean validateHeadOnly;
+    private final F6DigestAlgorithm digestAlgorithm;
+
+    public ObjectValidationConfig(final boolean checksum,
+                                  final boolean validateHeadOnly,
+                                  final F6DigestAlgorithm digestAlgorithm) {
+        this.checksum = checksum;
+        this.validateHeadOnly = validateHeadOnly;
+        this.digestAlgorithm = digestAlgorithm;
+    }
+
+    public boolean isChecksum() {
+        return checksum;
+    }
+
+    public boolean isValidateHeadOnly() {
+        return validateHeadOnly;
+    }
+
+    public F6DigestAlgorithm getDigestAlgorithm() {
+        return digestAlgorithm;
+    }
+}

--- a/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
@@ -35,6 +35,7 @@ import org.fcrepo.migration.foxml.ArchiveExportedFoxmlDirectoryObjectSource;
 import org.fcrepo.migration.foxml.InternalIDResolver;
 import org.fcrepo.migration.foxml.LegacyFSIDResolver;
 import org.fcrepo.migration.foxml.NativeFoxmlDirectoryObjectSource;
+import org.fcrepo.migration.validator.api.ObjectValidationConfig;
 import org.fcrepo.migration.validator.api.ValidationResultWriter;
 import org.fcrepo.storage.ocfl.CommitType;
 import org.fcrepo.storage.ocfl.DefaultOcflObjectSessionFactory;
@@ -124,6 +125,7 @@ public class ApplicationConfigurationHelper {
         return objectSource;
     }
 
+
     private MutableOcflRepository repository(final Fedora3ValidationConfig config, final Path workDir) {
         final var storage = FileSystemOcflStorage.builder()
                 .repositoryRoot(config.getOcflRepositoryRootDirectory().toPath())
@@ -190,15 +192,13 @@ public class ApplicationConfigurationHelper {
         return config.getThreadCount();
     }
 
-    public Boolean enableChecksums() {
-        return config.enableChecksums();
-    }
+    public ObjectValidationConfig getObjectValidationConfig() {
+        return new ObjectValidationConfig(config.enableChecksums(),
+                                          config.validateHeadOnly(),
+                                          config.getDigestAlgorithm());
 
     public Boolean checkNumObjects() {
         return config.checkNumObjects();
     }
 
-    public F6DigestAlgorithm getDigestAlgorithm() {
-        return config.getDigestAlgorithm();
-    }
 }

--- a/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
@@ -196,9 +196,9 @@ public class ApplicationConfigurationHelper {
         return new ObjectValidationConfig(config.enableChecksums(),
                                           config.validateHeadOnly(),
                                           config.getDigestAlgorithm());
+    }
 
     public Boolean checkNumObjects() {
         return config.checkNumObjects();
     }
-
 }

--- a/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
@@ -125,7 +125,6 @@ public class ApplicationConfigurationHelper {
         return objectSource;
     }
 
-
     private MutableOcflRepository repository(final Fedora3ValidationConfig config, final Path workDir) {
         final var storage = FileSystemOcflStorage.builder()
                 .repositoryRoot(config.getOcflRepositoryRootDirectory().toPath())

--- a/src/main/java/org/fcrepo/migration/validator/impl/F3ObjectValidationTask.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3ObjectValidationTask.java
@@ -18,6 +18,7 @@
 package org.fcrepo.migration.validator.impl;
 
 import org.fcrepo.migration.FedoraObjectProcessor;
+import org.fcrepo.migration.validator.api.ObjectValidationConfig;
 import org.fcrepo.migration.validator.api.ValidationResultWriter;
 import org.fcrepo.migration.validator.api.ValidationTask;
 import org.fcrepo.storage.ocfl.OcflObjectSessionFactory;
@@ -37,34 +38,31 @@ public class F3ObjectValidationTask extends ValidationTask {
     private final FedoraObjectProcessor processor;
     private final OcflObjectSessionFactory ocflObjectSessionFactory;
     private final ValidationResultWriter writer;
-    private final boolean enableChecksums;
-    private final F6DigestAlgorithm digestAlgorithm;
+    private final ObjectValidationConfig objectValidationConfig;
 
     /**
      * Constructor
-     *  @param processor The processor
+     *
+     * @param processor                The processor
      * @param ocflObjectSessionFactory The object session factory
-     * @param writer    The shared validation state
-     * @param enableChecksums Enable running of checksums on datastreams
-     * @param digestAlgorithm The digest algorithm to use
+     * @param writer                   The shared validation state
+     * @param objectValidationConfig   The config to use when validating objects
      */
     public F3ObjectValidationTask(final FedoraObjectProcessor processor,
                                   final OcflObjectSessionFactory ocflObjectSessionFactory,
                                   final ValidationResultWriter writer,
-                                  final boolean enableChecksums,
-                                  final F6DigestAlgorithm digestAlgorithm) {
+                                  final ObjectValidationConfig objectValidationConfig) {
         super();
         this.processor = processor;
         this.ocflObjectSessionFactory = ocflObjectSessionFactory;
         this.writer = writer;
-        this.enableChecksums = enableChecksums;
-        this.digestAlgorithm = digestAlgorithm;
+        this.objectValidationConfig = objectValidationConfig;
     }
 
     @Override
     public void run() {
         LOGGER.info("starting to process {} ", processor.getObjectInfo().getPid());
-        final var validator = new Fedora3ObjectValidator(ocflObjectSessionFactory, enableChecksums, digestAlgorithm);
+        final var validator = new Fedora3ObjectValidator(ocflObjectSessionFactory, objectValidationConfig);
         final var results = validator.validate(processor);
         writer.write(results);
     }

--- a/src/main/java/org/fcrepo/migration/validator/impl/F3ObjectValidationTaskBuilder.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3ObjectValidationTaskBuilder.java
@@ -19,6 +19,7 @@ package org.fcrepo.migration.validator.impl;
 
 import org.fcrepo.migration.FedoraObjectProcessor;
 import org.fcrepo.migration.validator.api.AbstractValidationTaskBuilder;
+import org.fcrepo.migration.validator.api.ObjectValidationConfig;
 
 /**
  * A builder for F3ObjectValidationTask instances.
@@ -27,24 +28,12 @@ import org.fcrepo.migration.validator.api.AbstractValidationTaskBuilder;
  */
 public class F3ObjectValidationTaskBuilder extends AbstractValidationTaskBuilder<F3ObjectValidationTask> {
 
-    private boolean enableChecksums;
-    private F6DigestAlgorithm digestAlgorithm;
     private FedoraObjectProcessor processor;
+    private ObjectValidationConfig objectValidationConfig;
 
     @Override
     public F3ObjectValidationTask build() {
-        return new F3ObjectValidationTask(processor, objectSessionFactory, writer, enableChecksums, digestAlgorithm);
-    }
-
-    /**
-     * @param enableChecksums
-     * @param digestAlgorithm
-     */
-    public F3ObjectValidationTaskBuilder enableChecksums(final boolean enableChecksums,
-                                                         final F6DigestAlgorithm digestAlgorithm) {
-        this.enableChecksums = enableChecksums;
-        this.digestAlgorithm = digestAlgorithm;
-        return this;
+        return new F3ObjectValidationTask(processor, objectSessionFactory, writer, objectValidationConfig);
     }
 
     /**
@@ -52,6 +41,11 @@ public class F3ObjectValidationTaskBuilder extends AbstractValidationTaskBuilder
      */
     public F3ObjectValidationTaskBuilder processor(final FedoraObjectProcessor processor) {
         this.processor = processor;
+        return this;
+    }
+
+    public F3ObjectValidationTaskBuilder withValidationConfig(ObjectValidationConfig objectValidationConfig) {
+        this.objectValidationConfig = objectValidationConfig;
         return this;
     }
 }

--- a/src/main/java/org/fcrepo/migration/validator/impl/F3ObjectValidationTaskBuilder.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3ObjectValidationTaskBuilder.java
@@ -44,7 +44,7 @@ public class F3ObjectValidationTaskBuilder extends AbstractValidationTaskBuilder
         return this;
     }
 
-    public F3ObjectValidationTaskBuilder withValidationConfig(ObjectValidationConfig objectValidationConfig) {
+    public F3ObjectValidationTaskBuilder withValidationConfig(final ObjectValidationConfig objectValidationConfig) {
         this.objectValidationConfig = objectValidationConfig;
         return this;
     }

--- a/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ObjectValidator.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ObjectValidator.java
@@ -19,6 +19,7 @@ package org.fcrepo.migration.validator.impl;
 
 import org.fcrepo.migration.FedoraObjectProcessor;
 import org.fcrepo.migration.handlers.ObjectAbstractionStreamingFedoraObjectHandler;
+import org.fcrepo.migration.validator.api.ObjectValidationConfig;
 import org.fcrepo.migration.validator.api.ValidationResult;
 import org.fcrepo.migration.validator.api.Validator;
 import org.fcrepo.storage.ocfl.OcflObjectSessionFactory;
@@ -43,14 +44,12 @@ public class Fedora3ObjectValidator implements Validator<FedoraObjectProcessor> 
 
 
     private final OcflObjectSessionFactory factory;
-    private final boolean enableChecksums;
-    private final F6DigestAlgorithm digestAlgorithm;
+    private final ObjectValidationConfig objectValidationConfig;
 
-    public Fedora3ObjectValidator(final OcflObjectSessionFactory factory, final boolean enableChecksums,
-                                  final F6DigestAlgorithm digestAlgorithm) {
+    public Fedora3ObjectValidator(final OcflObjectSessionFactory factory,
+                                  final ObjectValidationConfig objectValidationConfig) {
         this.factory = factory;
-        this.enableChecksums = enableChecksums;
-        this.digestAlgorithm = digestAlgorithm;
+        this.objectValidationConfig = objectValidationConfig;
     }
 
     @Override
@@ -61,7 +60,7 @@ public class Fedora3ObjectValidator implements Validator<FedoraObjectProcessor> 
             fedoraId = "info:fedora/" + objectInfo.getPid();
         }
         final var ocflSession = this.factory.newSession(fedoraId);
-        final var handler = new ValidatingObjectHandler(ocflSession, enableChecksums, digestAlgorithm);
+        final var handler = new ValidatingObjectHandler(ocflSession, objectValidationConfig);
 
         try {
             object.processObject(new ObjectAbstractionStreamingFedoraObjectHandler(handler));

--- a/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationConfig.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationConfig.java
@@ -29,6 +29,7 @@ import java.io.File;
 public class Fedora3ValidationConfig extends ValidationConfig {
 
     private boolean checksum;
+    private boolean validateHeadOnly;
     private boolean checkNumObjects;
     private F6DigestAlgorithm digestAlgorithm;
     private F3SourceTypes sourceType;
@@ -156,6 +157,18 @@ public class Fedora3ValidationConfig extends ValidationConfig {
 
     public F6DigestAlgorithm getDigestAlgorithm() {
         return digestAlgorithm;
+    }
+
+    public boolean validateHeadOnly() {
+        return validateHeadOnly;
+    }
+
+    /**
+     * @param validateHeadOnly
+     */
+    public Fedora3ValidationConfig setValidateHeadOnly(boolean validateHeadOnly) {
+        this.validateHeadOnly = validateHeadOnly;
+        return this;
     }
 
     public boolean checkNumObjects() {

--- a/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationConfig.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationConfig.java
@@ -166,7 +166,7 @@ public class Fedora3ValidationConfig extends ValidationConfig {
     /**
      * @param validateHeadOnly
      */
-    public Fedora3ValidationConfig setValidateHeadOnly(boolean validateHeadOnly) {
+    public Fedora3ValidationConfig setValidateHeadOnly(final boolean validateHeadOnly) {
         this.validateHeadOnly = validateHeadOnly;
         return this;
     }

--- a/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationExecutionManager.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationExecutionManager.java
@@ -18,6 +18,7 @@
 package org.fcrepo.migration.validator.impl;
 
 import org.fcrepo.migration.ObjectSource;
+import org.fcrepo.migration.validator.api.ObjectValidationConfig;
 import org.fcrepo.migration.validator.api.ValidationExecutionManager;
 import org.fcrepo.migration.validator.api.ValidationResultWriter;
 import org.fcrepo.migration.validator.api.ValidationTask;
@@ -47,8 +48,7 @@ public class Fedora3ValidationExecutionManager implements ValidationExecutionMan
     private final Set<String> objectsToValidate;
     private final AtomicLong count;
     private final Object lock;
-    private final Boolean checksum;
-    private final F6DigestAlgorithm digestAlgorithm;
+    private final ObjectValidationConfig objectValidationConfig;
     private final ApplicationConfigurationHelper config;
 
     /**
@@ -64,8 +64,7 @@ public class Fedora3ValidationExecutionManager implements ValidationExecutionMan
         executorService = Executors.newFixedThreadPool(config.getThreadCount());
         this.count = new AtomicLong(0);
         this.lock = new Object();
-        this.checksum = config.enableChecksums();
-        this.digestAlgorithm = config.getDigestAlgorithm();
+        this.objectValidationConfig = config.getObjectValidationConfig();
     }
 
     @Override
@@ -78,7 +77,7 @@ public class Fedora3ValidationExecutionManager implements ValidationExecutionMan
                 final var sourceObjectId = objectProcessor.getObjectInfo().getPid();
                 if (objectsToValidate.isEmpty() || objectsToValidate.contains(sourceObjectId)) {
                     final var task = new F3ObjectValidationTaskBuilder().processor(objectProcessor)
-                        .enableChecksums(checksum, digestAlgorithm)
+                        .withValidationConfig(objectValidationConfig)
                         .writer(writer)
                         .objectSessionFactory(ocflObjectSessionFactory)
                         .build();

--- a/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
@@ -149,7 +149,7 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
             return false;
         }
 
-        //check that last updated date:
+        // check that last updated date:
         objectProperties.listProperties().forEach(op -> {
             final var resolver = OCFL_PROPERTY_RESOLVERS.get(op.getName());
             String details = null;

--- a/src/test/java/org/fcrepo/migration/validator/AbstractValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/AbstractValidationIT.java
@@ -44,7 +44,10 @@ public abstract class AbstractValidationIT {
     }
 
     ResultsReportHandler doValidation(final File f3DatastreamsDir, final File f3ObjectsDir, final File f6OcflRootDir) {
-        final var config = getConfig(f3DatastreamsDir, f3ObjectsDir, f6OcflRootDir);
+        return doValidation(getConfig(f3DatastreamsDir, f3ObjectsDir, f6OcflRootDir));
+    }
+
+    ResultsReportHandler doValidation(final Fedora3ValidationConfig config) {
         final var configuration = new ApplicationConfigurationHelper(config);
         final var executionManager = new Fedora3ValidationExecutionManager(configuration);
         executionManager.doValidation();

--- a/src/test/java/org/fcrepo/migration/validator/VersionValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/VersionValidationIT.java
@@ -108,4 +108,26 @@ public class VersionValidationIT extends AbstractValidationIT {
         assertThat(errors).filteredOn(validation -> validation == LAST_MODIFIED_DATE).hasSize(2);
     }
 
+    @Test
+    public void testValidateHeadOnly() {
+        final var f3DatastreamsDir = new File(VERSIONS_BASE_DIR, "valid/f3/datastreams");
+        final var f3ObjectsDir = new File(VERSIONS_BASE_DIR, "valid/f3/objects");
+        final var f6OcflRootDir = new File(VERSIONS_BASE_DIR, "valid/f6/data/ocfl-root");
+        final var config = getConfig(f3DatastreamsDir, f3ObjectsDir, f6OcflRootDir);
+        config.setValidateHeadOnly(true);
+
+        final var reportHandler = doValidation(config);
+
+        // verify expected results
+        assertEquals("Should be no errors!", 0, reportHandler.getErrors().size());
+
+        // verify datastream metadata
+        // only 1 inline datastream with two versions, so we expect 2 results on all but size which should have none
+        final var validations = reportHandler.getPassed().stream()
+                                             .filter(result -> result.getValidationType() == BINARY_METADATA)
+                                             .map(ValidationResult::getDetails)
+                                             .collect(Collectors.toList());
+        assertThat(validations).allMatch(details -> details.contains("HEAD"));
+    }
+
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3688

# What does this Pull Request do?

* Add `--head-only` option for validating only the head datastreams

# What's new?

* Add `--head-only` option
* Created `ObjectValidationConfig` to encapsulate config for validation operations
* Add IT for checking only head objects

# How should this be tested?

Using a dataset which has versioned objects, run:
```
java -jar target/fcrepo-migration-validator-0.1.0-SNAPSHOT-driver.jar -s akubra -d /path/to/datastreams -o /path/to/objects -r /path/to/results -c /path/to/ocfl-root --head-only -R csv
```
Then verify the validations were only run on head datastreams:
```
cd /path/to/objects/csv
grep BINARY_METADATA *.csv | grep -v HEAD
```
If no versioned datastreams were validated, this should return no output.
