### PR TITLE
Add validation for label in object metadata

### DIFF
--- a/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
@@ -79,6 +79,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
     private static final Logger LOGGER = getLogger(Fedora3ObjectValidator.class);
 
+    public static final String F3_LABEL = "info:fedora/fedora-system:def/model#label";
     public static final String F3_STATE = "info:fedora/fedora-system:def/model#state";
     public static final String F3_CREATED_DATE = "info:fedora/fedora-system:def/model#createdDate";
     public static final String F3_LAST_MODIFIED_DATE = "info:fedora/fedora-system:def/view#lastModifiedDate";
@@ -99,6 +100,7 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
      * Properties which migrated to OCFL headers
      */
     private static final Map<String, PropertyResolver<String>> OCFL_PROPERTY_RESOLVERS = Map.of(
+        F3_LABEL, headers -> Optional.empty(),
         F3_STATE, headers -> Optional.empty(),
         F3_OWNER_ID, headers -> Optional.empty(),
         F3_CREATED_DATE, headers -> Optional.of(headers.getCreatedDate().toString()),

--- a/src/test/java/org/fcrepo/migration/validator/AbstractValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/AbstractValidationIT.java
@@ -25,6 +25,7 @@ import org.fcrepo.migration.validator.impl.ApplicationConfigurationHelper;
 import org.fcrepo.migration.validator.impl.F3SourceTypes;
 import org.fcrepo.migration.validator.impl.Fedora3ValidationConfig;
 import org.fcrepo.migration.validator.impl.Fedora3ValidationExecutionManager;
+import org.fcrepo.migration.validator.impl.ValidatingObjectHandler;
 import org.fcrepo.migration.validator.report.ReportGeneratorImpl;
 import org.fcrepo.migration.validator.report.ResultsReportHandler;
 import org.junit.After;
@@ -98,6 +99,35 @@ public abstract class AbstractValidationIT {
                 return CREATION_DATE;
             } else if (details.contains("size")) {
                 return SIZE;
+            }
+
+            throw new IllegalArgumentException("Unknown details type!");
+        }
+    }
+
+    /**
+     * Same as BinaryMetadataValidation but for Object metadata. Could probably be combined but keeping them distinct
+     * for now.
+     */
+    public enum ObjectMetadataValidation {
+        LABEL, OWNER, STATE, CREATED_DATE, LAST_MODIFIED_DATE;
+
+        public static ObjectMetadataValidation fromResult(final ValidationResult result) {
+            if (result.getValidationType() != ValidationResult.ValidationType.METADATA) {
+                throw new IllegalArgumentException("Enum type is only for BINARY_METADATA!");
+            }
+            final var details = result.getDetails();
+
+            if (details.contains(ValidatingObjectHandler.F3_LABEL)) {
+                return LABEL;
+            } else if (details.contains(ValidatingObjectHandler.F3_OWNER_ID)) {
+                return OWNER;
+            } else if (details.contains(ValidatingObjectHandler.F3_STATE)) {
+                return STATE;
+            } else if (details.contains(ValidatingObjectHandler.F3_CREATED_DATE)) {
+                return CREATED_DATE;
+            } else if (details.contains(ValidatingObjectHandler.F3_LAST_MODIFIED_DATE)) {
+                return LAST_MODIFIED_DATE;
             }
 
             throw new IllegalArgumentException("Unknown details type!");

--- a/src/test/java/org/fcrepo/migration/validator/AbstractValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/AbstractValidationIT.java
@@ -116,8 +116,8 @@ public abstract class AbstractValidationIT {
             if (result.getValidationType() != ValidationResult.ValidationType.METADATA) {
                 throw new IllegalArgumentException("Enum type is only for BINARY_METADATA!");
             }
-            final var details = result.getDetails();
 
+            final var details = result.getDetails();
             if (details.contains(ValidatingObjectHandler.F3_LABEL)) {
                 return LABEL;
             } else if (details.contains(ValidatingObjectHandler.F3_OWNER_ID)) {

--- a/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
@@ -34,10 +34,6 @@ import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.BINARY_METADATA;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.METADATA;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.SOURCE_OBJECT_EXISTS_IN_TARGET;
-import static org.fcrepo.migration.validator.impl.ValidatingObjectHandler.F3_CREATED_DATE;
-import static org.fcrepo.migration.validator.impl.ValidatingObjectHandler.F3_LABEL;
-import static org.fcrepo.migration.validator.impl.ValidatingObjectHandler.F3_LAST_MODIFIED_DATE;
-import static org.fcrepo.migration.validator.impl.ValidatingObjectHandler.F3_OWNER_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;

--- a/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
@@ -89,14 +89,9 @@ public class ObjectValidationIT extends AbstractValidationIT {
         // verify expected results
         final var errors = reportHandler.getErrors();
         assertThat(errors).hasSize(4)
-                          .anyMatch(result -> result.getDetails().contains(F3_OWNER_ID))
-                          .anyMatch(result -> result.getDetails().contains(F3_LABEL))
-                          .anyMatch(result -> result.getDetails().contains(F3_CREATED_DATE))
-                          .anyMatch(result -> result.getDetails().contains(F3_LAST_MODIFIED_DATE))
-                          .allSatisfy(result -> {
-                              assertThat(result.getValidationLevel()).isEqualTo(OBJECT);
-                              assertThat(result.getValidationType()).isEqualTo(METADATA);
-                          });
+                          .map(ObjectMetadataValidation::fromResult)
+                          .contains(ObjectMetadataValidation.LABEL, ObjectMetadataValidation.OWNER,
+                                    ObjectMetadataValidation.CREATED_DATE, ObjectMetadataValidation.LAST_MODIFIED_DATE);
     }
 
     @Test

--- a/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
@@ -22,6 +22,7 @@ import org.fcrepo.migration.validator.report.ResultsReportHandler;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,9 +63,8 @@ public class ObjectValidationIT extends AbstractValidationIT {
 
         // check that we have results for each of the f3 properties we look for
         final var metadataResults = resultsByType.get(METADATA);
-        assertThat(metadataResults).anyMatch(result -> result.getDetails().contains(F3_OWNER_ID))
-                                   .anyMatch(result -> result.getDetails().contains(F3_CREATED_DATE))
-                                   .anyMatch(result -> result.getDetails().contains(F3_LAST_MODIFIED_DATE));
+        assertThat(metadataResults).map(ObjectMetadataValidation::fromResult)
+                                   .containsAll(Arrays.asList(ObjectMetadataValidation.values()));
 
         // check datastream metadata
         // we have 7 datastreams overall -- 4 files and 3 inline

--- a/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
@@ -34,6 +34,7 @@ import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.METADATA;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.SOURCE_OBJECT_EXISTS_IN_TARGET;
 import static org.fcrepo.migration.validator.impl.ValidatingObjectHandler.F3_CREATED_DATE;
+import static org.fcrepo.migration.validator.impl.ValidatingObjectHandler.F3_LABEL;
 import static org.fcrepo.migration.validator.impl.ValidatingObjectHandler.F3_LAST_MODIFIED_DATE;
 import static org.fcrepo.migration.validator.impl.ValidatingObjectHandler.F3_OWNER_ID;
 import static org.junit.Assert.assertEquals;
@@ -87,8 +88,9 @@ public class ObjectValidationIT extends AbstractValidationIT {
 
         // verify expected results
         final var errors = reportHandler.getErrors();
-        assertThat(errors).hasSize(3)
+        assertThat(errors).hasSize(4)
                           .anyMatch(result -> result.getDetails().contains(F3_OWNER_ID))
+                          .anyMatch(result -> result.getDetails().contains(F3_LABEL))
                           .anyMatch(result -> result.getDetails().contains(F3_CREATED_DATE))
                           .anyMatch(result -> result.getDetails().contains(F3_LAST_MODIFIED_DATE))
                           .allSatisfy(result -> {

--- a/src/test/resources/test-object-validation/bad-metadata/f3/objects/dlmap/3/18/c4/info%3Afedora%2F1711.dl%3AUWPAbout
+++ b/src/test/resources/test-object-validation/bad-metadata/f3/objects/dlmap/3/18/c4/info%3Afedora%2F1711.dl%3AUWPAbout
@@ -5,7 +5,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
 <foxml:objectProperties>
 <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
-<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="History of UW–Platteville"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE=""/>
 <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="exampleOwner"/>
 <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2019-07-01T17:12:45.310Z"/>
 <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2019-07-25T17:43:56.210Z"/>


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3684

# What does this Pull Request do?

Adds a validation for the label (`info:fedora/fedora-system:def/model#label`) in object metadata. This is achieved by adding the label to the PropertyResolvers so that the validator sees that it is expected to be checked. 

# What's new?

* Added F3_LABEL to PropertyResolvers
* Created ObjectMetadataValidation enum to help with ObjectValidationIT assertions
* Updated ObjectValidationIT tests to look at all object metadata validations

# How should this be tested?

Run the validator against your data set and check that the label shows up in the METADATA validations.

e.g.
```
java -jar target/fcrepo-migration-validator-0.1.0-SNAPSHOT-driver.jar -s akubra -d src/test/resources/test-object-validation/deleted-validation-it/deleted-object/f3/datastreams -o src/test/resources/test-object-validation/deleted-validation-it/deleted-object/f3/objects -c src/test/resources/test-object-validation/deleted-validation-it/deleted-object/f6/data/ocfl-root -r validation-output
```

# Interested parties

@dbernstein 
