### PR TITLE
FCREPO-3757: Use a url encoded version for report links

### DIFF
--- a/src/main/java/org/fcrepo/migration/validator/api/ObjectReportSummary.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/ObjectReportSummary.java
@@ -17,6 +17,9 @@
  */
 package org.fcrepo.migration.validator.api;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -58,5 +61,13 @@ public class ObjectReportSummary {
     @JsonIgnore
     public String getReportFilename() {
         return reportFilename;
+    }
+
+    /**
+     * @return the encoded href for the html report
+     */
+    @JsonIgnore
+    public String getReportHref() {
+        return URLEncoder.encode(reportFilename, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/resources/templates/summary.ftl
+++ b/src/main/resources/templates/summary.ftl
@@ -64,7 +64,7 @@
     <h2>Objects with errors</h2>
     <ol>
       <#list errors as x>
-      <li><a href='${x.reportFilename}'>${x.reportFilename}</a></li>
+      <li><a href='${x.reportHref}'>${x.reportFilename}</a></li>
       </#list>
     </ol>
   </div>
@@ -74,7 +74,7 @@
     <h2>Object result details</h2>
     <ol>
       <#list objects as x>
-      <li><a href='${x.reportFilename}'>${x.reportFilename}</a></li>
+      <li><a href='${x.reportHref}'>${x.reportFilename}</a></li>
       </#list>
     </ol>
   </div>


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3757

# What does this Pull Request do?

Adds url encoding for hrefs to individual reports so that links to the reports do not fail.

# How should this be tested?

* Run a migration with pids that have characters which need to be url encoded, e.g. `:`
* Run the migration validator with html output
* Check that you can navigate to the individual reports for each pid

# Interested parties
@fcrepo/committers
