### PR TITLE
FCRPEO-3766: Too many open files

### DIFF
--- a/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ObjectValidator.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ObjectValidator.java
@@ -62,9 +62,8 @@ public class Fedora3ObjectValidator implements Validator<FedoraObjectProcessor> 
         final var ocflSession = this.factory.newSession(fedoraId);
         final var handler = new ValidatingObjectHandler(ocflSession, objectValidationConfig);
 
-        try {
+        try (object) {
             object.processObject(new ObjectAbstractionStreamingFedoraObjectHandler(handler));
-            object.close();
             return handler.getValidationResults();
         } catch (Exception ex) {
             LOGGER.error("Source object {} could not be read due to: {}", objectInfo.getPid(), ex.getMessage(), ex);

--- a/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ObjectValidator.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ObjectValidator.java
@@ -64,6 +64,7 @@ public class Fedora3ObjectValidator implements Validator<FedoraObjectProcessor> 
 
         try {
             object.processObject(new ObjectAbstractionStreamingFedoraObjectHandler(handler));
+            object.close();
             return handler.getValidationResults();
         } catch (Exception ex) {
             LOGGER.error("Source object {} could not be read due to: {}", objectInfo.getPid(), ex.getMessage(), ex);

--- a/src/main/java/org/fcrepo/migration/validator/report/HtmlReportHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/report/HtmlReportHandler.java
@@ -28,7 +28,6 @@ import org.fcrepo.migration.validator.api.ValidationResultsSummary;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Writer;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -98,11 +97,10 @@ public class HtmlReportHandler implements ReportHandler {
         data.put("errors", errors);
         data.put("errorCount", errors.size());
 
-        try {
+        final var file = new File(outputDir, filename);
+        file.getParentFile().mkdirs();
+        try (final var writer = new FileWriter(file)) {
             final Template template = config.getTemplate("object.ftl");
-            final var file = new File(outputDir, filename);
-            file.getParentFile().mkdirs();
-            final Writer writer = new FileWriter(file);
             template.process(data, writer);
         } catch (final IOException | TemplateException e) {
             throw new RuntimeException(e);
@@ -115,11 +113,9 @@ public class HtmlReportHandler implements ReportHandler {
     public String repositoryLevelReport(final ObjectValidationResults objectValidationResults) {
         final String filename = "repository.html";
 
-        try {
+        final var file = new File(outputDir, filename);
+        try (final var writer = new FileWriter(file)) {
             final Template template = config.getTemplate("repository.ftl");
-            final var file = new File(outputDir, filename);
-            file.getParentFile().mkdirs();
-            final Writer writer = new FileWriter(file);
             template.process(null, writer);
         } catch (final IOException | TemplateException e) {
             throw new RuntimeException(e);
@@ -156,9 +152,9 @@ public class HtmlReportHandler implements ReportHandler {
         data.put("errors", errors);
         data.put("errorCount", errors.size());
 
-        try {
+        final var file = new File(outputDir, reportFilename);
+        try (final var writer = new FileWriter(file)) {
             final Template template = config.getTemplate("summary.ftl");
-            final Writer writer = new FileWriter(new File(outputDir, reportFilename));
             template.process(data, writer);
         } catch (final IOException | TemplateException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3766

# What does this Pull Request do?

Closes a few resources in places they were left open

# What's new?

* Close FedoraObjectProcessors after validation processing is complete
* Wrap FileWriter using try with resources

# How should this be tested?

I set a few breakpoints in the Driver in order to check open files (`lsof -p ${PID}`) in two spots while debugging:
* After validation (`executionManager.doValidate`) no foxml files should be open
* After report generation (`generator.generate()`) no html files should be open

# Interested parties
@fcrepo/committers
