### PR TITLE
Block when creating ValidationTasks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compiler.plugin.version>3.8.0</compiler.plugin.version>
         <fcrepo-build-tools.version>6.0.0-alpha-1</fcrepo-build-tools.version>
-        <fcrepo-migration-utils.version>6.0.0</fcrepo-migration-utils.version>
-        <fcrepo.storage.ocfl.version>6.0.0</fcrepo.storage.ocfl.version>
+        <fcrepo-migration-utils.version>6.1.0-SNAPSHOT</fcrepo-migration-utils.version>
+        <fcrepo.storage.ocfl.version>6.1.0-SNAPSHOT</fcrepo.storage.ocfl.version>
         <ocfl-java.version>1.1.0</ocfl-java.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
         <jackson.version>2.11.1</jackson.version>

--- a/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
@@ -464,7 +464,8 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
             // compare file size by looking at the filesystem
             final var sourceFile = dsVersion.getFile();
             final var result = sourceFile.map(file -> {
-                final var ocflRelativePath = ocflObjectVersion.getFile(headers.getFilename()).getStorageRelativePath();
+                final var ocflRelativePath = ocflObjectVersion.getFile(headers.getContentPath())
+                                                              .getStorageRelativePath();
                 final var targetPath = ocflRoot.resolve(ocflRelativePath);
                 if (Files.notExists(targetPath)) {
                     return builder.fail(BINARY_SIZE, format(notFound, version, "target"));


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3766

# What does this Pull Request do?

Part 2 of 3766. I found that when running the validator on the brown dataset I had ~10xx files open, which was close to the number of objects in the set. For larger datasets, this will continue to grow as the executor uses an unbounded queue. To compensate for this I added a Semaphore when submitting tasks. 

# What's new?

* Use a Semaphore when creating ValidationTasks
* Bump fedora dependencies to 6.1.0-SNAPSHOT
* Use getContentPath to resolve ocfl files on disk

# How should this be tested?

Run the validation tool again a dataset and inspect the open files and see fewer than before.

e.g.
```
$ java -jar target/fcrepo-migration-validator-1.1.0-SNAPSHOT-driver.jar -r /data/migration/export-results -c /data/migration/f6/data/ocfl-root -s legacy -d /data/migration/brown/repoarchive/datastreams_2019 -o /data/migration/brown/repostore/data_2019/objects
$ lsof -p ${PID} | wc -l
```

# Additional Notes:

Wasn't sure about the number of permits to allow in the Semaphore so just went with the max threads. I used that in await as well in order to kind of simulate the behavior from before since the behavior of the count + lock sort of fit in the semaphore acquisition, though it is an odd use imo. Was initially considering returning the futures for the ValidationTasks and blocking until all are complete.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
