### PR TITLE
FCREPO-3812: Add failure only reporting option

### DIFF
--- a/src/main/java/org/fcrepo/migration/validator/Driver.java
+++ b/src/main/java/org/fcrepo/migration/validator/Driver.java
@@ -104,6 +104,10 @@ public class Driver implements Callable<Integer> {
                         description = "Validate objects in the Inactive state as deleted.")
     private boolean deleteInactive;
 
+    @CommandLine.Option(names = {"--failure-only"}, order = 19,
+                        description = "Report only objects which have failed validations.")
+    private boolean failureOnly;
+
     @CommandLine.Option(names = {"--debug"}, order = 30, description = "Enables debug logging")
     private boolean debug;
 
@@ -125,6 +129,7 @@ public class Driver implements Callable<Integer> {
         config.setOcflRepositoryRootDirectory(ocflRootDirectory);
         config.setObjectsToValidate(objectsToValidate);
         config.setDeleteInactive(deleteInactive);
+        config.setFailureOnly(failureOnly);
         LOGGER.info("Configuration created: {}", config);
 
         LOGGER.info("Preparing to execute validation run...");

--- a/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
@@ -64,7 +64,7 @@ public class ApplicationConfigurationHelper {
     }
 
     public ValidationResultWriter validationResultWriter() {
-        return new FileSystemValidationResultWriter(config.getJsonOutputDirectory());
+        return new FileSystemValidationResultWriter(config.getJsonOutputDirectory(), config.isFailureOnly());
     }
 
     public ObjectSource objectSource() {

--- a/src/main/java/org/fcrepo/migration/validator/impl/F3ObjectValidationTask.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3ObjectValidationTask.java
@@ -49,7 +49,7 @@ public class F3ObjectValidationTask extends ValidationTask {
 
     @Override
     public void run() {
-        LOGGER.info("starting to process {} ", processor.getObjectInfo().getPid());
+        LOGGER.info("Processing {} ", processor.getObjectInfo().getPid());
         final var validator = new Fedora3ObjectValidator(ocflObjectSessionFactory, objectValidationConfig);
         final var results = validator.validate(processor);
         writer.write(results);

--- a/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationConfig.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationConfig.java
@@ -17,6 +17,7 @@ import java.io.File;
 public class Fedora3ValidationConfig extends ValidationConfig {
 
     private boolean checksum;
+    private boolean failureOnly;
     private boolean deleteInactive;
     private boolean validateHeadOnly;
     private boolean checkNumObjects;
@@ -181,6 +182,18 @@ public class Fedora3ValidationConfig extends ValidationConfig {
      */
     public Fedora3ValidationConfig setDeleteInactive(final boolean deleteInactive) {
         this.deleteInactive = deleteInactive;
+        return this;
+    }
+
+    public boolean isFailureOnly() {
+        return failureOnly;
+    }
+
+    /**
+     * @param failureOnly
+     */
+    public Fedora3ValidationConfig setFailureOnly(final boolean failureOnly) {
+        this.failureOnly = failureOnly;
         return this;
     }
 }

--- a/src/main/java/org/fcrepo/migration/validator/impl/FileSystemValidationResultWriter.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/FileSystemValidationResultWriter.java
@@ -50,7 +50,7 @@ public class FileSystemValidationResultWriter implements ValidationResultWriter 
                 continue;
             }
 
-            LOGGER.info("Writing of results here: {}", result);
+            LOGGER.debug("Writing of results here: {}", result);
             final var jsonFilePath = this.validationRoot.resolve(resolvePathToJsonResult(result));
             final var file = jsonFilePath.toFile();
             file.getParentFile().mkdirs();

--- a/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
@@ -289,7 +289,7 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
         final var property = op.getName();
         final var sourceValue = op.getValue();
 
-        LOGGER.info("PID = {}, object property: name = {}, value = {}", pid, property, sourceValue);
+        LOGGER.debug("PID = {}, object property: name = {}, value = {}", pid, property, sourceValue);
         final var resolver = OCFL_PROPERTY_RESOLVERS.get(property);
         if (resolver != null) {
             final var success = "pid: %s -> properties match: f3 prop name=%s, source=%s, target=%s";
@@ -303,7 +303,7 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
                         .map(targetVal -> resolver.equals(sourceValue, targetVal) ?
                                  builder.ok(METADATA, format(success, pid, property, sourceValue, targetVal)) :
                                  builder.fail(METADATA, format(error, pid, property, sourceValue, targetVal)))
-                        .orElse(builder.fail(METADATA, format(notFound, pid, property, sourceValue)));
+                        .orElseGet(() -> builder.fail(METADATA, format(notFound, pid, property, sourceValue)));
             validationResults.add(result);
         }
     }
@@ -584,7 +584,7 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
                     return builder.ok(BINARY_SIZE, format(success, version, sourceBytes));
                 }
                 return builder.fail(BINARY_SIZE, format(error, version, sourceBytes, targetBytes));
-            }).orElse(builder.fail(BINARY_SIZE, format(notFound, version, "source")));
+            }).orElseGet(() -> builder.fail(BINARY_SIZE, format(notFound, version, "source")));
             validationResults.add(result);
         }
     }
@@ -636,6 +636,7 @@ public class ValidatingObjectHandler implements FedoraObjectVersionHandler {
         }
 
         public ValidationResult fail(final ValidationType type, final String details) {
+            LOGGER.info("[{}] {} validation failed: {}", sourceObjectId, type, details);
             return new ValidationResult(indexCounter++, FAIL, validationLevel, type, sourceObjectId, targetObjectId,
                                         sourceResource, targetResource, details);
         }

--- a/src/main/resources/templates/summary.ftl
+++ b/src/main/resources/templates/summary.ftl
@@ -49,7 +49,7 @@
     <h2>Summary</h2>
     <table>
       <tr>
-        <td>Total objects:</td>
+        <td>Total object reports:</td>
         <td>${objectCount}</td>
       </tr>
       <tr>
@@ -70,6 +70,7 @@
   </div>
   </#if>
 
+  <#if objectCount gt 0>
   <div class="container">
     <h2>Object result details</h2>
     <ol>
@@ -78,5 +79,6 @@
       </#list>
     </ol>
   </div>
+  </#if>
 </body>
 </html>

--- a/src/test/java/org/fcrepo/migration/validator/ReportGeneratorIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ReportGeneratorIT.java
@@ -57,7 +57,7 @@ public class ReportGeneratorIT extends AbstractValidationIT {
     }
 
     @Test
-    public void testAllPassHTML() throws Exception {
+    public void testAllPass() throws Exception {
         final var f3ObjectsDir = new File(FIXTURES_BASE_DIR, "valid/f3/objects");
         final var f3DatastreamsDir = new File(FIXTURES_BASE_DIR, "valid/f3/datastreams");
         final var f6OcflRootDir = new File(FIXTURES_BASE_DIR, "valid/f6/data/ocfl-root");
@@ -85,7 +85,7 @@ public class ReportGeneratorIT extends AbstractValidationIT {
     }
 
     @Test
-    public void testOnlyWriteFailureAllPassHTML() throws IOException {
+    public void testOnlyWriteFailureAllPass() throws IOException {
         final var f3ObjectsDir = new File(FIXTURES_BASE_DIR, "valid/f3/objects");
         final var f3DatastreamsDir = new File(FIXTURES_BASE_DIR, "valid/f3/datastreams");
         final var f6OcflRootDir = new File(FIXTURES_BASE_DIR, "valid/f6/data/ocfl-root");

--- a/src/test/java/org/fcrepo/migration/validator/ReportGeneratorIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ReportGeneratorIT.java
@@ -1,0 +1,125 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.migration.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import edu.wisc.library.ocfl.api.OcflRepository;
+import org.fcrepo.migration.validator.impl.ApplicationConfigurationHelper;
+import org.fcrepo.migration.validator.impl.Fedora3ValidationExecutionManager;
+import org.fcrepo.migration.validator.report.CsvReportHandler;
+import org.fcrepo.migration.validator.report.HtmlReportHandler;
+import org.fcrepo.migration.validator.report.ReportGeneratorImpl;
+import org.fcrepo.migration.validator.report.ReportType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ *
+ * @author mikejritter
+ */
+@RunWith(Parameterized.class)
+public class ReportGeneratorIT extends AbstractValidationIT {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { ReportType.html }, { ReportType.csv }
+        });
+    }
+
+    /**
+     * Regex to ignore non-object reports
+     */
+    private static final Predicate<String> IGNORE = Pattern.compile("index|repository|migration-validation-summary")
+               .asPredicate()
+               .negate();
+
+    private final ReportType reportType;
+
+    public ReportGeneratorIT(final ReportType reportType) {
+        this.reportType = reportType;
+    }
+
+    @Test
+    public void testAllPassHTML() throws Exception {
+        final var f3ObjectsDir = new File(FIXTURES_BASE_DIR, "valid/f3/objects");
+        final var f3DatastreamsDir = new File(FIXTURES_BASE_DIR, "valid/f3/datastreams");
+        final var f6OcflRootDir = new File(FIXTURES_BASE_DIR, "valid/f6/data/ocfl-root");
+
+        final var config = getConfig(f3DatastreamsDir, f3ObjectsDir, f6OcflRootDir);
+        final var reportDir = config.getReportDirectory(reportType);
+
+        final var configHelper = new ApplicationConfigurationHelper(config);
+        final var executionManager = new Fedora3ValidationExecutionManager(configHelper);
+        executionManager.doValidation();
+
+        final var handler = reportType == ReportType.html ? new HtmlReportHandler(reportDir)
+                                                          : new CsvReportHandler(reportDir, reportType);
+        final var generator = new ReportGeneratorImpl(config.getJsonOutputDirectory(), handler);
+        generator.generate();
+
+        final var ocflRepository = configHelper.ocflRepository();
+        final var objectIds = getExpectedObjectReports(ocflRepository, reportType);
+
+        // get object reports and validate
+        final var objectReports = getObjectReports(reportDir, IGNORE);
+        assertThat(objectReports)
+            .hasSize(objectIds.size())
+            .allMatch(objectIds::contains);
+    }
+
+    @Test
+    public void testOnlyWriteFailureAllPassHTML() throws IOException {
+        final var f3ObjectsDir = new File(FIXTURES_BASE_DIR, "valid/f3/objects");
+        final var f3DatastreamsDir = new File(FIXTURES_BASE_DIR, "valid/f3/datastreams");
+        final var f6OcflRootDir = new File(FIXTURES_BASE_DIR, "valid/f6/data/ocfl-root");
+
+        final var config = getConfig(f3DatastreamsDir, f3ObjectsDir, f6OcflRootDir);
+        config.setFailureOnly(true);
+        final var reportDir = config.getReportDirectory(reportType);
+
+        final var configHelper = new ApplicationConfigurationHelper(config);
+        final var executionManager = new Fedora3ValidationExecutionManager(configHelper);
+        executionManager.doValidation();
+
+        final var handler = reportType == ReportType.html ? new HtmlReportHandler(reportDir)
+                                                          : new CsvReportHandler(reportDir, reportType);
+        final var generator = new ReportGeneratorImpl(config.getJsonOutputDirectory(), handler);
+        generator.generate();
+
+        // filter out non-object reports
+        final var objectReports = getObjectReports(reportDir, IGNORE);
+        assertThat(objectReports).isEmpty();
+    }
+
+    public List<String> getExpectedObjectReports(final OcflRepository repository, final ReportType reportType) {
+        return repository.listObjectIds()
+                         .map(objectId -> objectId.substring("info:fedora/".length()))
+                         .map(objectId -> objectId + reportType.getExtension())
+                         .collect(Collectors.toList());
+    }
+
+    public List<String> getObjectReports(final Path reportDir, final Predicate<String> filter) throws IOException {
+        return Files.list(reportDir)
+                    .map(Path::getFileName)
+                    .map(Path::toString)
+                    .filter(filter)
+                    .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3812

# What does this Pull Request do?

* Add flag for reporting only failed validations
* Update logic to account for failed only flag

# What's new?

Updates the FileSystemValidationResultWriter to be able to write out only failed validations. 

# How should this be tested?

* Migrate some data
* Run the validator with the `--failure-only` flag, e.g.
   ```
   java -jar target/fcrepo-migration-validator-1.2.0-SNAPSHOT-driver.jar -c /data/migration/f6-migration/data/ocfl-root -d /data/migration/f3dataset/datastreams -o /data/migration/f3dataset/objects -s legacy -r /data/migration/report --failure-only
   ```
* Check the resulting files only contain validations which failed, some something like `grep -R OK json/` should return no matches.
 
# Additional Notes:

* This is a little awkward when there are no errors as you're left with either and empty csv file or a mostly blank HTML report. I could disable that portion of the report gen as well if there are no errors, or generate something for this condition. 
* Likewise, there weren't any tests covering report generation, so I haven't added any. This could be done before merging if desired. 

# Interested parties
@fcrepo/committers
