### PR TITLE
Fail after exceptions from ValidationTasks

### DIFF
--- a/src/main/java/org/fcrepo/migration/validator/Driver.java
+++ b/src/main/java/org/fcrepo/migration/validator/Driver.java
@@ -146,6 +146,8 @@ public class Driver implements Callable<Integer> {
             final var generator = new ReportGeneratorImpl(config.getJsonOutputDirectory(), reportHandler);
             final var summaryFile = generator.generate();
             LOGGER.info("Validation report written to: {}", summaryFile);
+        } else {
+            LOGGER.warn("Skipping report writing due to exception");
         }
 
         return completedRun ? 0 : 1;

--- a/src/main/java/org/fcrepo/migration/validator/Driver.java
+++ b/src/main/java/org/fcrepo/migration/validator/Driver.java
@@ -134,19 +134,21 @@ public class Driver implements Callable<Integer> {
 
         LOGGER.info("Preparing to execute validation run...");
         final var executionManager = new Fedora3ValidationExecutionManager(new ApplicationConfigurationHelper(config));
-        executionManager.doValidation();
+        final var completedRun = executionManager.doValidation();
 
-        final ReportHandler reportHandler;
-        if (reportType == ReportType.html) {
-            reportHandler = new HtmlReportHandler(config.getReportDirectory(reportType));
-        } else {
-            reportHandler = new CsvReportHandler(config.getReportDirectory(reportType), reportType);
+        if (completedRun) {
+            final ReportHandler reportHandler;
+            if (reportType == ReportType.html) {
+                reportHandler = new HtmlReportHandler(config.getReportDirectory(reportType));
+            } else {
+                reportHandler = new CsvReportHandler(config.getReportDirectory(reportType), reportType);
+            }
+            final var generator = new ReportGeneratorImpl(config.getJsonOutputDirectory(), reportHandler);
+            final var summaryFile = generator.generate();
+            LOGGER.info("Validation report written to: {}", summaryFile);
         }
-        final var generator = new ReportGeneratorImpl(config.getJsonOutputDirectory(), reportHandler);
-        final var summaryFile = generator.generate();
-        LOGGER.info("Validation report written to: {}", summaryFile);
 
-        return 0;
+        return completedRun ? 0 : 1;
     }
 
     /**

--- a/src/main/java/org/fcrepo/migration/validator/api/ValidationExecutionManager.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/ValidationExecutionManager.java
@@ -14,6 +14,7 @@ public interface ValidationExecutionManager {
 
     /**
      * Perform a validation run.
+     * @return
      */
-    void doValidation();
+    boolean doValidation();
 }

--- a/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import edu.wisc.library.ocfl.api.OcflRepository;
@@ -37,6 +36,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
 import static edu.wisc.library.ocfl.api.util.Enforce.expressionTrue;

--- a/src/main/java/org/fcrepo/migration/validator/impl/FileSystemValidationResultWriter.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/FileSystemValidationResultWriter.java
@@ -11,6 +11,7 @@ import org.fcrepo.migration.validator.api.ValidationResultWriter;
 import org.slf4j.Logger;
 
 import java.io.FileWriter;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -57,8 +58,8 @@ public class FileSystemValidationResultWriter implements ValidationResultWriter 
             try (final var writer = new FileWriter(file)) {
                 final var resultStr = objectMapper.writeValueAsString(result);
                 writer.write(resultStr);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            } catch (final IOException ex) {
+                throw new RuntimeException(ex);
             }
         }
     }

--- a/src/test/java/org/fcrepo/migration/validator/AbstractValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/AbstractValidationIT.java
@@ -102,7 +102,7 @@ public abstract class AbstractValidationIT {
 
         public static ObjectMetadataValidation fromResult(final ValidationResult result) {
             if (result.getValidationType() != ValidationResult.ValidationType.METADATA) {
-                throw new IllegalArgumentException("Enum type is only for BINARY_METADATA!");
+                throw new IllegalArgumentException("Enum type is only for METADATA!");
             }
 
             final var details = result.getDetails();

--- a/src/test/java/org/fcrepo/migration/validator/ExceptingValidationResultWriter.java
+++ b/src/test/java/org/fcrepo/migration/validator/ExceptingValidationResultWriter.java
@@ -1,0 +1,23 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.migration.validator;
+
+import java.util.List;
+
+import org.fcrepo.migration.validator.api.ValidationResult;
+import org.fcrepo.migration.validator.api.ValidationResultWriter;
+
+/**
+ * ValidationResultWriter which throws an exception
+ *
+ * @author mikejritter
+ */
+public class ExceptingValidationResultWriter implements ValidationResultWriter {
+    @Override
+    public void write(final List<ValidationResult> results) {
+        throw new RuntimeException("failure to write");
+    }
+}

--- a/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
@@ -6,6 +6,7 @@
 package org.fcrepo.migration.validator;
 
 import org.fcrepo.migration.validator.api.ValidationResult;
+import org.fcrepo.migration.validator.impl.Fedora3ValidationExecutionManager;
 import org.fcrepo.migration.validator.report.ResultsReportHandler;
 import org.junit.Test;
 
@@ -128,6 +129,20 @@ public class ObjectValidationIT extends AbstractValidationIT {
             assertEquals("Should be validation level OBJECT", OBJECT, result.getValidationLevel());
             assertEquals("Should be validation type BINARY_HEAD_COUNT", BINARY_HEAD_COUNT, result.getValidationType());
         }, () -> fail("Unable to find error for BINARY_HEAD_COUNT"));
+    }
+
+    @Test
+    public void testResultWriterException() {
+        final File f3DatastreamsDir = new File(FIXTURES_BASE_DIR, "valid/f3/datastreams");
+        final File f3ObjectsDir = new File(FIXTURES_BASE_DIR, "valid/f3/objects");
+        final File f6OcflRootDir = new File(FIXTURES_BASE_DIR, "valid/f6/data/ocfl-root");
+
+        final var config = getConfig(f3DatastreamsDir, f3ObjectsDir, f6OcflRootDir);
+        final var configHelper = new TestApplicationConfigurationHelper(config);
+        final var executionManager = new Fedora3ValidationExecutionManager(configHelper);
+        final var completedRun = executionManager.doValidation();
+
+        assertThat(completedRun).isEqualTo(false);
     }
 
 }

--- a/src/test/java/org/fcrepo/migration/validator/TestApplicationConfigurationHelper.java
+++ b/src/test/java/org/fcrepo/migration/validator/TestApplicationConfigurationHelper.java
@@ -1,0 +1,26 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.migration.validator;
+
+import org.fcrepo.migration.validator.api.ValidationResultWriter;
+import org.fcrepo.migration.validator.impl.ApplicationConfigurationHelper;
+import org.fcrepo.migration.validator.impl.Fedora3ValidationConfig;
+
+/**
+ * Class which extends ApplicationConfigurationHelper in order to supply certain test cases
+ *
+ * @author mikejritter
+ */
+public class TestApplicationConfigurationHelper extends ApplicationConfigurationHelper {
+    public TestApplicationConfigurationHelper(final Fedora3ValidationConfig config) {
+        super(config);
+    }
+
+    @Override
+    public ValidationResultWriter validationResultWriter() {
+        return new ExceptingValidationResultWriter();
+    }
+}


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3811

# What does this Pull Request do?

Stops execution of validation tasks when exceptions occur in the tasks which are unhandled. 

# What's new?

* Add flag for signaling abort in the ValidationExecutionManager
* Create ValidationTasks as CompletableFutures for better exception handling
* Add test which throws a RuntimeException when writing ValidationResults
* Typos/import updates

# How should this be tested?

The best way to test this is to have the `ValidationResultWriter` fail, which can be done by specifying a `--results-dir` which cannot be written, e.g.:
```
java -jar target/fcrepo-migration-validator-1.2.0-SNAPSHOT-driver.jar -c /data/migration/f6-migration/data/ocfl-root -d /data/migration/f3dataset/2018/datastreams -o /data/migration/f3dataset/2018/objects -s legacy -r /reports -R csv
```

# Additional Notes

I also opted to not attempt to write reports if any exceptions occurred from the ValidationExecutionManager. Since the only exception we re-throw is the `RuntimeException` in the `FileSystemValidationResultWriter`, I felt it was safe to do so as we wouldn't be able to write any of the reports.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
