### PR TITLE
FCREPO-3845: Head Only Repository Count Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compiler.plugin.version>3.8.0</compiler.plugin.version>
         <fcrepo-build-tools.version>6.0.0</fcrepo-build-tools.version>
-        <fcrepo-migration-utils.version>6.1.0</fcrepo-migration-utils.version>
-        <fcrepo.storage.ocfl.version>6.1.0</fcrepo.storage.ocfl.version>
+        <fcrepo-migration-utils.version>6.3.0-SNAPSHOT</fcrepo-migration-utils.version>
+        <fcrepo.storage.ocfl.version>6.3.0-SNAPSHOT</fcrepo.storage.ocfl.version>
         <ocfl-java.version>1.3.1</ocfl-java.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
         <jackson.version>2.11.1</jackson.version>

--- a/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
@@ -15,7 +15,7 @@ import edu.wisc.library.ocfl.api.OcflRepository;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
 import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig;
 import edu.wisc.library.ocfl.core.path.mapper.LogicalPathMappers;
-import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
+import edu.wisc.library.ocfl.core.storage.OcflStorageBuilder;
 import org.apache.commons.lang3.SystemUtils;
 import org.fcrepo.migration.ObjectSource;
 import org.fcrepo.migration.foxml.AkubraFSIDResolver;
@@ -123,8 +123,8 @@ public class ApplicationConfigurationHelper {
     }
 
     private MutableOcflRepository repository(final Fedora3ValidationConfig config, final Path workDir) {
-        final var storage = FileSystemOcflStorage.builder()
-                .repositoryRoot(config.getOcflRepositoryRootDirectory().toPath())
+        final var storage = OcflStorageBuilder.builder()
+                .fileSystem(config.getOcflRepositoryRootDirectory().toPath())
                 .build();
         final var logicalPathMapper = SystemUtils.IS_OS_WINDOWS ?
                 LogicalPathMappers.percentEncodingWindowsMapper() : LogicalPathMappers.percentEncodingLinuxMapper();

--- a/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidationTask.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidationTask.java
@@ -7,7 +7,6 @@ package org.fcrepo.migration.validator.impl;
 
 import java.util.Optional;
 
-import edu.wisc.library.ocfl.api.OcflRepository;
 import org.fcrepo.migration.validator.api.ValidationResultWriter;
 import org.fcrepo.migration.validator.api.ValidationTask;
 import org.slf4j.Logger;
@@ -22,54 +21,28 @@ public class F3RepositoryValidationTask extends ValidationTask {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(F3RepositoryValidationTask.class);
 
-    private final long numObjects;
-    private boolean checkNumObjects;
-    private final OcflRepository ocflRepository;
     private final ValidationResultWriter writer;
-    private ApplicationConfigurationHelper config;
-
-    /**
-     * Constructor
-     *
-     * @param checkNumObjects
-     * @param numObjects
-     * @param ocflRepository
-     * @param writer
-     */
-    public F3RepositoryValidationTask(final boolean checkNumObjects,
-                                      final long numObjects,
-                                      final OcflRepository ocflRepository,
-                                      final ValidationResultWriter writer) {
-        this.writer = writer;
-        this.numObjects = numObjects;
-        this.ocflRepository = ocflRepository;
-        this.checkNumObjects = checkNumObjects;
-    }
+    private final ApplicationConfigurationHelper config;
 
     /**
      * Constructor
      *
      * @param config
-     * @param numObjects
-     * @param ocflRepository
      * @param writer
      */
     public F3RepositoryValidationTask(final ApplicationConfigurationHelper config,
-                                      final long numObjects,
-                                      final OcflRepository ocflRepository,
                                       final ValidationResultWriter writer) {
-        this.writer = writer;
-        this.numObjects = numObjects;
-        this.ocflRepository = ocflRepository;
         this.config = config;
+        this.writer = writer;
     }
 
 
     @Override
     public ValidationTask get() {
-        LOGGER.info("starting repository processor");
+        LOGGER.info("Starting repository processor");
+        final var repository = config.ocflRepository();
         final var repositoryValidator = new F3RepositoryValidator(config);
-        final var results = repositoryValidator.validate(ocflRepository);
+        final var results = repositoryValidator.validate(repository);
         writer.write(results);
         return this;
     }

--- a/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidationTask.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidationTask.java
@@ -23,9 +23,10 @@ public class F3RepositoryValidationTask extends ValidationTask {
     private static final Logger LOGGER = LoggerFactory.getLogger(F3RepositoryValidationTask.class);
 
     private final long numObjects;
-    private final boolean checkNumObjects;
+    private boolean checkNumObjects;
     private final OcflRepository ocflRepository;
     private final ValidationResultWriter writer;
+    private ApplicationConfigurationHelper config;
 
     /**
      * Constructor
@@ -45,10 +46,29 @@ public class F3RepositoryValidationTask extends ValidationTask {
         this.checkNumObjects = checkNumObjects;
     }
 
+    /**
+     * Constructor
+     *
+     * @param config
+     * @param numObjects
+     * @param ocflRepository
+     * @param writer
+     */
+    public F3RepositoryValidationTask(final ApplicationConfigurationHelper config,
+                                      final long numObjects,
+                                      final OcflRepository ocflRepository,
+                                      final ValidationResultWriter writer) {
+        this.writer = writer;
+        this.numObjects = numObjects;
+        this.ocflRepository = ocflRepository;
+        this.config = config;
+    }
+
+
     @Override
     public ValidationTask get() {
         LOGGER.info("starting repository processor");
-        final var repositoryValidator = new F3RepositoryValidator(checkNumObjects, numObjects);
+        final var repositoryValidator = new F3RepositoryValidator(config);
         final var results = repositoryValidator.validate(ocflRepository);
         writer.write(results);
         return this;

--- a/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidator.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidator.java
@@ -7,16 +7,25 @@ package org.fcrepo.migration.validator.impl;
 
 import static java.lang.String.format;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import edu.wisc.library.ocfl.api.OcflRepository;
+import org.fcrepo.migration.FedoraObjectProcessor;
+import org.fcrepo.migration.ObjectSource;
 import org.fcrepo.migration.validator.api.RepositoryValidator;
+import org.fcrepo.migration.validator.api.ValidationHandler;
 import org.fcrepo.migration.validator.api.ValidationResult;
 import org.fcrepo.migration.validator.api.ValidationResult.Status;
 import org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel;
 import org.fcrepo.migration.validator.api.ValidationResult.ValidationType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A validator for repository scoped validations for F3 against F6
@@ -25,27 +34,35 @@ import org.fcrepo.migration.validator.api.ValidationResult.ValidationType;
  */
 public class F3RepositoryValidator implements RepositoryValidator {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(F3RepositoryValidator.class);
+
+    private long deleted = 0;
+    private long objects = 0;
+
+    private final boolean headOnly;
     private final boolean enableCheckNumObjects;
     private final AtomicInteger index;
-    private final long numObjectsF3;
+    private final boolean deleteInactive;
+    private final ObjectSource source;
     private final List<ValidationResult> validationResults = new ArrayList<>();
 
-    /**
-     * Constructor
-     *
-     * @param enableCheckNumObjects
-     * @param numObjects
-     */
-    public F3RepositoryValidator(final boolean enableCheckNumObjects, final long numObjects) {
-        this.numObjectsF3 = numObjects;
+    public F3RepositoryValidator(final ApplicationConfigurationHelper config) {
         this.index = new AtomicInteger(0);
-        this.enableCheckNumObjects = enableCheckNumObjects;
+        this.source = config.objectSource();
+        this.enableCheckNumObjects = config.checkNumObjects();
+        this.headOnly = config.getObjectValidationConfig().isValidateHeadOnly();
+        this.deleteInactive = config.getObjectValidationConfig().deleteInactive();
     }
 
     @Override
     public List<ValidationResult> validate(final OcflRepository repository) {
         if (enableCheckNumObjects) {
-            checkObjects(repository);
+            try {
+                countF3();
+                checkObjects(repository);
+            } catch (IOException e) {
+                LOGGER.error("Error getting Fedora3 repository count", e);
+            }
         }
 
         return validationResults;
@@ -57,19 +74,55 @@ public class F3RepositoryValidator implements RepositoryValidator {
 
         try (final var ocflIds = ocflRepository.listObjectIds()) {
             final long ocflCount = ocflIds.count();
+            final long f3Count = headOnly ? objects - deleted : objects;
 
             final ValidationResult result;
-            if (ocflCount == numObjectsF3) {
+            if (ocflCount == f3Count) {
                 result = new ValidationResult(index.getAndIncrement(), Status.OK, ValidationLevel.REPOSITORY,
-                                              ValidationType.REPOSITORY_RESOURCE_COUNT, format(success, numObjectsF3));
+                                              ValidationType.REPOSITORY_RESOURCE_COUNT, format(success, f3Count));
             } else {
                 result = new ValidationResult(index.getAndIncrement(), Status.FAIL, ValidationLevel.REPOSITORY,
                                               ValidationType.REPOSITORY_RESOURCE_COUNT,
-                                              format(error, numObjectsF3, ocflCount));
+                                              format(error, objects, f3Count));
             }
 
             validationResults.add(result);
         }
     }
 
+    /**
+     * Iterate the Fedora 3 repository (again) in order to get a count of objects. If the object has the state
+     * object property, run an additional check to see if it has been deleted. Errors don't matter as they are handled
+     * during object validation.
+     *
+     * @throws IOException
+     */
+    private void countF3() throws IOException {
+        for (FedoraObjectProcessor processor : source) {
+            objects++;
+            final var xml = processor.getObjectInfo().getFoxmlPath();
+            try (processor; Stream<String> lines = Files.lines(xml)) {
+                lines.filter(line -> line.contains(ValidationHandler.F3_STATE))
+                     .findFirst()
+                     .ifPresent(this::testDeleted);
+            }
+        }
+    }
+
+    /**
+     * Increment the deleted counter if the object state was deleted
+     *
+     * @param xml the object property xml
+     */
+    private void testDeleted(final String xml) {
+        // Instead of parsing the xml, just extract the value attr
+        final Pattern pattern = Pattern.compile("value=\"(.*)\"", Pattern.CASE_INSENSITIVE);
+        final var matcher = pattern.matcher(xml);
+        if (matcher.find()) {
+            final var state = F3State.fromString(matcher.group(1));
+            if (state.isDeleted(deleteInactive)) {
+                deleted++;
+            }
+        }
+    }
 }

--- a/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationExecutionManager.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationExecutionManager.java
@@ -130,8 +130,6 @@ public class Fedora3ValidationExecutionManager implements ValidationExecutionMan
      * @param throwable the exception thrown by the ValidationTask
      */
     private void finishTask(final ValidationTask task, final Throwable throwable) {
-        semaphore.release();
-
         //TODO Handle this in such a away that it is captured in the final report
         //https://jira.lyrasis.org/browse/FCREPO-3633
         if (throwable != null) {
@@ -140,6 +138,8 @@ public class Fedora3ValidationExecutionManager implements ValidationExecutionMan
         } else {
             task.getPid().ifPresent(resumeManager::completed);
         }
+
+        semaphore.release();
     }
 
 

--- a/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationExecutionManager.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationExecutionManager.java
@@ -67,13 +67,10 @@ public class Fedora3ValidationExecutionManager implements ValidationExecutionMan
     @Override
     public boolean doValidation() {
         try {
-            // track count of objects processed for final f3 to ocfl validation
-            var totalCount = 0L;
             var halted = false;
 
             // When iterating, we block on the semaphore as creating a new ObjectProcessor will open a file handle
             for (final var objectProcessor : source) {
-                totalCount++;
                 if (resumeManager.accept(objectProcessor.getObjectInfo().getPid())) {
                     if (abort.get() || halted) {
                         break;
@@ -100,14 +97,13 @@ public class Fedora3ValidationExecutionManager implements ValidationExecutionMan
                 }
             }
 
-            // only run repository validator if doing a full run
-            final var repository = config.ocflRepository();
-            //final var checkNumObjects = config.checkNumObjects() && objectsToValidate.isEmpty() && !halted;
-            final var repositoryTask = new F3RepositoryValidationTask(config, totalCount, repository, writer);
-            submit(repositoryTask);
+            // only run repository validator for full runs
+            if (!halted) {
+                final var repositoryTask = new F3RepositoryValidationTask(config, writer);
+                submit(repositoryTask);
+            }
 
             awaitCompletion();
-
             resumeManager.updateResumeFile();
         } catch (Exception ex) {
             throw new RuntimeException(ex);

--- a/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationExecutionManager.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/Fedora3ValidationExecutionManager.java
@@ -102,8 +102,8 @@ public class Fedora3ValidationExecutionManager implements ValidationExecutionMan
 
             // only run repository validator if doing a full run
             final var repository = config.ocflRepository();
-            final var checkNumObjects = config.checkNumObjects() && objectsToValidate.isEmpty() && !halted;
-            final var repositoryTask = new F3RepositoryValidationTask(checkNumObjects, totalCount, repository, writer);
+            //final var checkNumObjects = config.checkNumObjects() && objectsToValidate.isEmpty() && !halted;
+            final var repositoryTask = new F3RepositoryValidationTask(config, totalCount, repository, writer);
             submit(repositoryTask);
 
             awaitCompletion();


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3845

# What does this Pull Request do?

Updates the repository count validation to work with the head only changes to the migration-utils. This includes expecting deleted objects to no longer be in the OCFL repository when counting.

# What's new?

* Iterate the F3 repository when doing the repository count
* Update logic for executing F3RepositoryValidator to run when not halted
* Add tests to RepoValidationIT for head only and deleted objects

# How should this be tested?

* Compile and run tests for the migration validator with `mvn verify`
* Migrate a dataset with deleted objects (in my case the Brown data) with the head only flag
    ```
    java -jar target/migration-utils-6.3.0-SNAPSHOT-driver.jar -d /data/migration/brown/repoarchive/datastreams_2019/ -o /data/migration/brown/repostore/data_2019/objects -a /data/migration/brown-migrated -i work/ -t legacy -H
    ```
* Run the migration validator against the migrated dataset using both the head only and repository count flags
    ```
    java -jar target/fcrepo-migration-validator-1.2.0-SNAPSHOT-driver.jar -s legacy -d /data/migration/brown/repoarchive/datastreams_2019/ -o /data/migration/brown/repostore/data_2019/objects -c /data/migration/brown-migration/data/ocfl-root -r /data/migration/validation-results -H -n
    ```
* Verify the results of the migration validator in both `/data/migration/validation-results/index.html` and `/data/migration/validation-results/repository.html`

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers