### PR TITLE
OCFL 2.1.0 and Update CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+* text
+*.json text
+*.java text diff=java
+
+# Keep the line endings for some test files by setting to binary
+# This is to allow tests to pass in windows and *nix
+*.0 binary
+ADMINMD binary
+BIB0 binary
+props binary
+TECH0 binary
+TECH1 binary
+
+# Images
+*REF binary
+*THUMB binary
+*MASTER0 binary
+
+# Fedora 6
+*.nt eol=lf
+*.json eol=lf
+*.sha512 eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,21 +17,23 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        java: ['11']
+        experimental: [false]
+        include:
+          - java: 17
+            os: ubuntu-latest
+            experimental: true
     steps:
     - name: Git support longpaths
       run: git config --global core.longpaths true
     - name: Checkout
-      uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/checkout@v4
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v4
       with:
-        java-version: 11
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+        cache: 'maven'
     - name: Build with Maven
       run: mvn -B -U clean install
 
@@ -43,10 +45,11 @@ jobs:
       - name: Git support longpaths
         run: git config --global core.longpaths true
       - name: Checkout fcrepo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: 11
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         java: ['11']
         experimental: [false]
         include:

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <fcrepo.storage.ocfl.version>6.3.0</fcrepo.storage.ocfl.version>
         <ocfl-java.version>1.5.0</ocfl-java.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
-        <jackson.version>2.11.1</jackson.version>
+        <jackson.version>2.17.1</jackson.version>
         <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
         <license.plugin.version>3.0</license.plugin.version>
         <project.java.source>11</project.java.source>
@@ -248,7 +248,7 @@
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.30</version>
+            <version>2.3.32</version>
         </dependency>
 
         <dependency>
@@ -280,41 +280,41 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.0-jre</version>
+            <version>33.2.1-jre</version>
         </dependency>
 
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
-            <version>4.5.2</version>
+            <version>4.7.6</version>
         </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.8.0</version>
+            <version>2.16.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.11</version>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.14</version>
+            <version>1.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>2.0.12</version>
         </dependency>
 
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -326,13 +326,13 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.19.0</version>
+            <version>3.26.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.22.0</version>
+            <version>5.11.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compiler.plugin.version>3.8.0</compiler.plugin.version>
         <fcrepo-build-tools.version>6.0.0</fcrepo-build-tools.version>
-        <fcrepo-migration-utils.version>6.3.0</fcrepo-migration-utils.version>
-        <fcrepo.storage.ocfl.version>6.3.0</fcrepo.storage.ocfl.version>
-        <ocfl-java.version>1.5.0</ocfl-java.version>
+        <fcrepo-migration-utils.version>6.6.0-SNAPSHOT</fcrepo-migration-utils.version>
+        <fcrepo.storage.ocfl.version>6.4.0-SNAPSHOT</fcrepo.storage.ocfl.version>
+        <ocfl-java.version>2.1.0</ocfl-java.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
         <jackson.version>2.17.1</jackson.version>
         <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
@@ -223,7 +223,7 @@
         </dependency>
 
         <dependency>
-            <groupId>edu.wisc.library.ocfl</groupId>
+            <groupId>io.ocfl</groupId>
             <artifactId>ocfl-java-aws</artifactId>
             <version>${ocfl-java.version}</version>
             <!--

--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,11 @@
             <artifactId>slf4j-api</artifactId>
             <version>2.0.12</version>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.6</version>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -323,21 +323,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>2.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.26.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>5.11.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/fcrepo/migration/validator/Driver.java
+++ b/src/main/java/org/fcrepo/migration/validator/Driver.java
@@ -34,7 +34,7 @@ import static picocli.CommandLine.Help.Visibility.ALWAYS;
  * @author dbernstein
  */
 @CommandLine.Command(name = "fcrepo-migration-validator", mixinStandardHelpOptions = true, sortOptions = false,
-        version = "0.1.0-SNAPSHOT")
+        version = "Fedora Migration Validator 1.3.0")
 public class Driver implements Callable<Integer> {
 
     private static final Logger LOGGER = getLogger(Driver.class);

--- a/src/main/java/org/fcrepo/migration/validator/api/ObjectValidationConfig.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/ObjectValidationConfig.java
@@ -8,7 +8,7 @@ package org.fcrepo.migration.validator.api;
 import java.io.File;
 import java.nio.file.Path;
 
-import edu.wisc.library.ocfl.api.OcflRepository;
+import io.ocfl.api.OcflRepository;
 import org.fcrepo.migration.validator.impl.F6DigestAlgorithm;
 
 /**

--- a/src/main/java/org/fcrepo/migration/validator/api/ObjectValidationResults.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/ObjectValidationResults.java
@@ -5,6 +5,8 @@
  */
 package org.fcrepo.migration.validator.api;
 
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -40,6 +42,21 @@ public class ObjectValidationResults {
         }
 
         return results.stream().findFirst().map(ValidationResult::getSourceObjectId).orElse("unknown");
+    }
+
+    /**
+     * This method returns an encoded version of the object id for use as a filesystem path
+     * @return the encoded object-id
+     */
+    public String getEncodedObjectId() {
+        if (results == null || results.isEmpty()) {
+            return "unknown";
+        }
+
+        return results.stream().findFirst()
+                      .map(ValidationResult::getSourceObjectId)
+                      .map(objectId -> URLEncoder.encode(objectId, Charset.defaultCharset()))
+                      .orElse("unknown");
     }
 
     /**

--- a/src/main/java/org/fcrepo/migration/validator/api/RepositoryValidator.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/RepositoryValidator.java
@@ -5,7 +5,7 @@
  */
 package org.fcrepo.migration.validator.api;
 
-import edu.wisc.library.ocfl.api.OcflRepository;
+import io.ocfl.api.OcflRepository;
 
 /**
  * An interface for performing validations across the repository.

--- a/src/main/java/org/fcrepo/migration/validator/api/ValidationHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/ValidationHandler.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import com.google.common.hash.Funnels;
 import com.google.common.hash.HashCode;
 import com.google.common.io.ByteStreams;
-import edu.wisc.library.ocfl.api.model.OcflObjectVersion;
+import io.ocfl.api.model.OcflObjectVersion;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFNode;

--- a/src/main/java/org/fcrepo/migration/validator/api/ValidationTask.java
+++ b/src/main/java/org/fcrepo/migration/validator/api/ValidationTask.java
@@ -15,5 +15,5 @@ import java.util.function.Supplier;
  */
 public abstract class ValidationTask implements Supplier<ValidationTask> {
 
-    abstract public Optional<String> getPid();
+    public abstract Optional<String> getPid();
 }

--- a/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelper.java
@@ -10,12 +10,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Suppliers;
-import edu.wisc.library.ocfl.api.MutableOcflRepository;
-import edu.wisc.library.ocfl.api.OcflRepository;
-import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
-import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig;
-import edu.wisc.library.ocfl.core.path.mapper.LogicalPathMappers;
-import edu.wisc.library.ocfl.core.storage.OcflStorageBuilder;
+import io.ocfl.api.MutableOcflRepository;
+import io.ocfl.api.OcflRepository;
+import io.ocfl.core.OcflRepositoryBuilder;
+import io.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig;
+import io.ocfl.core.path.mapper.LogicalPathMappers;
+import io.ocfl.core.storage.OcflStorageBuilder;
 import org.apache.commons.lang3.SystemUtils;
 import org.fcrepo.migration.ObjectSource;
 import org.fcrepo.migration.foxml.AkubraFSIDResolver;
@@ -40,8 +40,8 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
-import static edu.wisc.library.ocfl.api.util.Enforce.expressionTrue;
-import static edu.wisc.library.ocfl.api.util.Enforce.notNull;
+import static io.ocfl.api.util.Enforce.expressionTrue;
+import static io.ocfl.api.util.Enforce.notNull;
 
 /**
  * A helper class for configuring and creating application components.
@@ -124,16 +124,17 @@ public class ApplicationConfigurationHelper {
 
     private MutableOcflRepository repository(final Fedora3ValidationConfig config, final Path workDir) {
         final var storage = OcflStorageBuilder.builder()
-                .fileSystem(config.getOcflRepositoryRootDirectory().toPath())
-                .build();
+                                              .fileSystem(config.getOcflRepositoryRootDirectory().toPath())
+                                              .build();
         final var logicalPathMapper = SystemUtils.IS_OS_WINDOWS ?
-                LogicalPathMappers.percentEncodingWindowsMapper() : LogicalPathMappers.percentEncodingLinuxMapper();
+                                      LogicalPathMappers.percentEncodingWindowsMapper() :
+                                      LogicalPathMappers.percentEncodingLinuxMapper();
 
         return new OcflRepositoryBuilder().storage(storage)
-                .defaultLayoutConfig(new HashedNTupleLayoutConfig())
-                .logicalPathMapper(logicalPathMapper)
-                .workDir(workDir)
-                .buildMutable();
+                                          .defaultLayoutConfig(new HashedNTupleLayoutConfig())
+                                          .logicalPathMapper(logicalPathMapper)
+                                          .workDir(workDir)
+                                          .buildMutable();
     }
 
     /**
@@ -164,7 +165,7 @@ public class ApplicationConfigurationHelper {
                 .maximumSize(512)
                 .expireAfterAccess(Duration.ofMinutes(10))
                 .build();
-        // https://jira.lyrasis.org/browse/FCREPO-3632:
+
         return new DefaultOcflObjectSessionFactory(repositorySupplier.get(),
                 workDirectory,
                 objectMapper,

--- a/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidator.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F3RepositoryValidator.java
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import edu.wisc.library.ocfl.api.OcflRepository;
+import io.ocfl.api.OcflRepository;
 import org.fcrepo.migration.FedoraObjectProcessor;
 import org.fcrepo.migration.ObjectSource;
 import org.fcrepo.migration.validator.api.RepositoryValidator;

--- a/src/main/java/org/fcrepo/migration/validator/impl/F6DigestAlgorithm.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/F6DigestAlgorithm.java
@@ -8,7 +8,7 @@ package org.fcrepo.migration.validator.impl;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
-import edu.wisc.library.ocfl.api.model.DigestAlgorithm;
+import io.ocfl.api.model.DigestAlgorithm;
 
 /**
  * Supported digest algorithms for ocfl

--- a/src/main/java/org/fcrepo/migration/validator/impl/FileSystemValidationResultWriter.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/FileSystemValidationResultWriter.java
@@ -12,8 +12,11 @@ import org.slf4j.Logger;
 
 import java.io.FileWriter;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 import static org.fcrepo.migration.validator.api.ValidationResult.Status.OK;
 import static org.fcrepo.migration.validator.impl.ValidationResultUtils.resolvePathToJsonResult;
@@ -30,6 +33,7 @@ public class FileSystemValidationResultWriter implements ValidationResultWriter 
 
     private final Path validationRoot;
     private final boolean writeFailureOnly;
+    private final UnaryOperator<String> pathEncoder;
 
     /**
      * Constructor
@@ -41,6 +45,8 @@ public class FileSystemValidationResultWriter implements ValidationResultWriter 
         this.validationRoot = validationRoot;
         this.writeFailureOnly = writeFailureOnly;
         validationRoot.toFile().mkdirs();
+
+        pathEncoder = original -> URLEncoder.encode(original, Charset.defaultCharset());
     }
 
     @Override
@@ -51,8 +57,8 @@ public class FileSystemValidationResultWriter implements ValidationResultWriter 
                 continue;
             }
 
-            LOGGER.debug("Writing of results here: {}", result);
-            final var jsonFilePath = this.validationRoot.resolve(resolvePathToJsonResult(result));
+            final var jsonFilePath = this.validationRoot.resolve(resolvePathToJsonResult(result, pathEncoder));
+            LOGGER.debug("Writing of results here: {}", jsonFilePath);
             final var file = jsonFilePath.toFile();
             file.getParentFile().mkdirs();
             try (final var writer = new FileWriter(file)) {

--- a/src/main/java/org/fcrepo/migration/validator/impl/HeadOnlyValidationHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/HeadOnlyValidationHandler.java
@@ -18,8 +18,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import edu.wisc.library.ocfl.api.OcflRepository;
-import edu.wisc.library.ocfl.api.model.ObjectVersionId;
+import io.ocfl.api.OcflRepository;
+import io.ocfl.api.model.ObjectVersionId;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;

--- a/src/main/java/org/fcrepo/migration/validator/impl/ResumeManagerImpl.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ResumeManagerImpl.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ResumeManagerImpl implements ResumeManager {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(ResumeManagerImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResumeManagerImpl.class);
 
     private final boolean acceptAll;
     private final Path resumeFile;
@@ -69,14 +69,14 @@ public class ResumeManagerImpl implements ResumeManager {
     }
 
     public boolean accept(final String pid) {
-        final String logMsg = "PID: " + pid + ", accept? ";
+        final String logMsg = "PID: {}, accept? {}";
 
         if (!acceptAll && processedPids.contains(pid)) {
-            LOGGER.debug(logMsg + false);
+            LOGGER.debug(logMsg, pid, false);
             return false;
         }
 
-        LOGGER.debug(logMsg + true);
+        LOGGER.debug(logMsg, pid, true);
         return true;
     }
 

--- a/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
@@ -55,7 +55,7 @@ import org.slf4j.Logger;
  * @author dbernstein
  */
 public class ValidatingObjectHandler implements ValidationHandler {
-    private static final Logger LOGGER = getLogger(Fedora3ObjectValidator.class);
+    private static final Logger LOGGER = getLogger(ValidatingObjectHandler.class);
 
     private F3State objectState;
     private ObjectInfo objectInfo;

--- a/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ValidatingObjectHandler.java
@@ -30,8 +30,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.collect.Sets;
-import edu.wisc.library.ocfl.api.OcflRepository;
-import edu.wisc.library.ocfl.api.model.ObjectVersionId;
+import io.ocfl.api.OcflRepository;
+import io.ocfl.api.model.ObjectVersionId;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;

--- a/src/main/java/org/fcrepo/migration/validator/impl/ValidationResultUtils.java
+++ b/src/main/java/org/fcrepo/migration/validator/impl/ValidationResultUtils.java
@@ -11,6 +11,7 @@ import org.fcrepo.migration.validator.api.ValidationResult;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.function.UnaryOperator;
 
 /**
  * A utility class
@@ -26,20 +27,20 @@ public class ValidationResultUtils {
      * Resolves the relative (i.e. to the validation output directory) path
      * of the json file associated with the validation result.
      *
-     * @param result The result
+     * @param result      The result
+     * @param pathEncoder The encoder for the objectId
      * @return The file path
      */
-    public static Path resolvePathToJsonResult(final ValidationResult result) {
+    public static Path resolvePathToJsonResult(final ValidationResult result,
+                                               final UnaryOperator<String> pathEncoder) {
         final var pathSegments = new ArrayList<String>();
         final var sourceId = result.getSourceObjectId();
         if (sourceId != null) {
             final var segments = Splitter.fixedLength(4).splitToList(DigestUtils.sha1Hex(sourceId)).subList(0, 4);
             pathSegments.addAll(segments);
-            pathSegments.add(sourceId);
+            pathSegments.add(pathEncoder.apply(sourceId));
         }
         pathSegments.add("result-" + result.getIndex() + ".json");
         return Path.of(String.join(File.separator, pathSegments));
-
-
     }
 }

--- a/src/main/java/org/fcrepo/migration/validator/report/CsvReportHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/report/CsvReportHandler.java
@@ -61,7 +61,7 @@ public class CsvReportHandler implements ReportHandler {
 
     @Override
     public String objectLevelReport(final ObjectValidationResults objectValidationResults) {
-        final var csvFile = outputDir.resolve(objectValidationResults.getObjectId() + reportType.getExtension());
+        final var csvFile = outputDir.resolve(objectValidationResults.getEncodedObjectId() + reportType.getExtension());
         return writeValidationResults(csvFile, objectValidationResults);
     }
 

--- a/src/main/java/org/fcrepo/migration/validator/report/HtmlReportHandler.java
+++ b/src/main/java/org/fcrepo/migration/validator/report/HtmlReportHandler.java
@@ -78,7 +78,7 @@ public class HtmlReportHandler implements ReportHandler {
      */
     @Override
     public String objectLevelReport(final ObjectValidationResults objectValidationResults) {
-        final var id = objectValidationResults.getObjectId();
+        final var id = objectValidationResults.getEncodedObjectId();
         final var filename = id + ".html";
         final var success = objectValidationResults.getPassed();
         final var errors = objectValidationResults.getErrors();

--- a/src/test/java/org/fcrepo/migration/validator/HeadOnlyIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/HeadOnlyIT.java
@@ -48,7 +48,7 @@ public class HeadOnlyIT extends AbstractValidationIT {
                                              .filter(result -> result.getValidationType() == BINARY_METADATA)
                                              .map(ValidationResult::getDetails)
                                              .collect(Collectors.toList());
-        assertThat(validations).allMatch(details -> details.contains("HEAD"));
+        assertThat(validations).isNotEmpty().allMatch(details -> details.contains("HEAD"));
     }
 
     @Test
@@ -107,7 +107,7 @@ public class HeadOnlyIT extends AbstractValidationIT {
         config.setValidateHeadOnly(true);
 
         final var reportHandler = doValidation(config);
-        Assertions.assertThat(reportHandler.getErrors()).hasSize(0);
+        Assertions.assertThat(reportHandler.getErrors()).isEmpty();
     }
 
     @Test

--- a/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ObjectValidationIT.java
@@ -142,7 +142,7 @@ public class ObjectValidationIT extends AbstractValidationIT {
         final var executionManager = new Fedora3ValidationExecutionManager(configHelper);
         final var completedRun = executionManager.doValidation();
 
-        assertThat(completedRun).isEqualTo(false);
+        assertThat(completedRun).isFalse();
     }
 
 }

--- a/src/test/java/org/fcrepo/migration/validator/ReportGeneratorIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ReportGeneratorIT.java
@@ -121,10 +121,11 @@ public class ReportGeneratorIT extends AbstractValidationIT {
     }
 
     public List<String> getObjectReports(final Path reportDir, final Predicate<String> filter) throws IOException {
-        return Files.list(reportDir)
-                    .map(Path::getFileName)
-                    .map(Path::toString)
-                    .filter(filter)
-                    .collect(Collectors.toList());
+        try (var reports = Files.list(reportDir)) {
+            return reports.map(Path::getFileName)
+                .map(Path::toString)
+                .filter(filter)
+                .collect(Collectors.toList());
+        }
     }
 }

--- a/src/test/java/org/fcrepo/migration/validator/ReportGeneratorIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ReportGeneratorIT.java
@@ -9,6 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -113,6 +115,7 @@ public class ReportGeneratorIT extends AbstractValidationIT {
     public List<String> getExpectedObjectReports(final OcflRepository repository, final ReportType reportType) {
         return repository.listObjectIds()
                          .map(objectId -> objectId.substring("info:fedora/".length()))
+                         .map(objectId -> URLEncoder.encode(objectId, Charset.defaultCharset()))
                          .map(objectId -> objectId + reportType.getExtension())
                          .collect(Collectors.toList());
     }

--- a/src/test/java/org/fcrepo/migration/validator/ReportGeneratorIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/ReportGeneratorIT.java
@@ -18,7 +18,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import edu.wisc.library.ocfl.api.OcflRepository;
+import io.ocfl.api.OcflRepository;
 import org.fcrepo.migration.validator.impl.ApplicationConfigurationHelper;
 import org.fcrepo.migration.validator.impl.Fedora3ValidationExecutionManager;
 import org.fcrepo.migration.validator.report.CsvReportHandler;


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3946


# What does this Pull Request do?
* Add gitattributes
* Updates ocfl-java to 2.1.0
* Other dependency updates where applicable
* Removed unused dependencies
* Update ci to run on Windows
* URLEncode paths to allow writing of result files and reports on Windows
* Minor qol updates for formatting/styling

# What's new?

**OCFL 2.1.0**
The dependency update for ocfl 2.1.0 were the main goal of this. This is to bring the migration validator in line with the migration-utils, which it uses when iterating over the Fedora 3 repositories. 

The other dependency changes I don't believe had any changes required, with the exception of adding logback-classic in order for the slf4j update to work properly.

**CI Update**
I updated the ci configuration as well which had some other cascading changes. Notable adding Windows to the build matrix caused many tests to fail. Paths containing colons and other characters were one source of failure, which was resolved by URLEncoding the paths before writing (this is the same approach the migration-utils takes, though I'm not sure if it only applies it on Windows or not). 

Line endings in the test data were also causing failures which was resolved by adding a `.gitattributes`. It might be better to remigrate the test data, however annoying that may be, but the attributes seem to work well enough. I had to enumerate each file and set the type to `binary` so that no attempt to change them would be made.

Other changes are fairly minor, e.g. wrapping a Stream in a try-with-resources, fixing the class name for a logger, etc. Little qol things that I figured I'd get while I can.

# How should this be tested?

* Run the tests as a sanity check: `mvn clean verify`
* Migrate a dataset, e.g.
```
java -jar target/migration-utils-6.5.0-SNAPSHOT-driver.jar -t legacy -d /data/fedora/migration/brown-single/repoarchive/ -o /data/fedora/migration/brown-single/repostore/ -a /data/fedora/migration/fedora6-brown-single -i work/
```
* Run the migration validator, e.g.
```
java -jar target/fcrepo-migration-validator-1.3.0-SNAPSHOT-driver.jar -s legacy -d /data/fedora/migration/brown-single/repoarchive/ -o /data/fedora/migration/brown-single/repostore/ -c /data/fedora/migration/fedora6-brown-single/data/ocfl-root -r results
```

# Additional Notes:
It would be good to run this on Windows as well, I only did in on Linux against a single object dataset.

# Interested parties
@fcrepo/committers
