### PR TITLE
FCREPO-4099: Add Codecov reporting and raise coverage above 90%

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,17 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -B -U clean install
+      run: >
+        mvn -B -U clean
+        org.jacoco:jacoco-maven-plugin:0.8.12:prepare-agent
+        install
+        org.jacoco:jacoco-maven-plugin:0.8.12:report
+
+    - name: Upload coverage to Codecov
+      if: matrix.os == 'ubuntu-latest' && matrix.java == '11'
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   deploy:
     if: github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # fcrepo-migration-validator
 
 ![Build Status](https://github.com/fcrepo-exts/fcrepo-migration-validator/workflows/Java%20CI%20with%20Maven/badge.svg)
+[![codecov](https://codecov.io/gh/fcrepo-exts/fcrepo-migration-validator/branch/main/graph/badge.svg)](https://codecov.io/gh/fcrepo-exts/fcrepo-migration-validator)
 
 A command-line tool for validating migrations of Fedora 3 datasets to Fedora 6.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+# Codecov configuration for fcrepo-migration-validator.
+# Coverage is produced by the jacoco-maven-plugin (merged unit + integration
+# report at target/site/jacoco/jacoco.xml) and uploaded from CI.
+coverage:
+  precision: 2
+  round: down
+  range: "90...100"
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 1%
+    patch:
+      default:
+        target: 90%
+        threshold: 1%
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: false

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <compiler.plugin.version>3.8.0</compiler.plugin.version>
         <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
         <fcrepo-build-tools.version>6.0.0</fcrepo-build-tools.version>
-        <fcrepo-migration-utils.version>6.6.0-SNAPSHOT</fcrepo-migration-utils.version>
+        <fcrepo-migration-utils.version>6.5.1</fcrepo-migration-utils.version>
         <fcrepo.storage.ocfl.version>6.4.0-SNAPSHOT</fcrepo.storage.ocfl.version>
         <ocfl-java.version>2.1.0</ocfl-java.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
@@ -250,7 +250,7 @@
         <dependency>
             <groupId>org.fcrepo.migration</groupId>
             <artifactId>migration-utils</artifactId>
-            <version>6.6.0-SNAPSHOT</version>
+            <version>${fcrepo-migration-utils.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <project.copyrightYear>2020</project.copyrightYear>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compiler.plugin.version>3.8.0</compiler.plugin.version>
+        <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
         <fcrepo-build-tools.version>6.0.0</fcrepo-build-tools.version>
         <fcrepo-migration-utils.version>6.6.0-SNAPSHOT</fcrepo-migration-utils.version>
         <fcrepo.storage.ocfl.version>6.4.0-SNAPSHOT</fcrepo.storage.ocfl.version>
@@ -195,12 +196,48 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.0.0-M3</version>
+                <configuration>
+                    <argLine>${jacoco.agent.it.arg}</argLine>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.plugin.version}</version>
+                <executions>
+                    <!-- Unit and integration test runs both append to a single exec file so
+                      that the report reflects merged coverage. -->
+                    <execution>
+                        <id>prepare-unit</id>
+                        <goals><goal>prepare-agent</goal></goals>
+                        <configuration>
+                            <destFile>${project.build.directory}/jacoco.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>prepare-it</id>
+                        <goals><goal>prepare-agent-integration</goal></goals>
+                        <configuration>
+                            <destFile>${project.build.directory}/jacoco.exec</destFile>
+                            <propertyName>jacoco.agent.it.arg</propertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals><goal>report</goal></goals>
+                        <configuration>
+                            <destFile>${project.build.directory}/jacoco.exec</destFile>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/org/fcrepo/migration/validator/Driver.java
+++ b/src/main/java/org/fcrepo/migration/validator/Driver.java
@@ -182,12 +182,22 @@ public class Driver implements Callable<Integer> {
      * @param args Command line arguments
      */
     public static void main(final String[] args) {
+        run(args);
+    }
+
+    /**
+     * Parses and runs the command without terminating the JVM.
+     *
+     * @param args Command line arguments
+     * @return the exit code of the run
+     */
+    static int run(final String[] args) {
         final Driver driver = new Driver();
         final CommandLine cmd = new CommandLine(driver);
         cmd.registerConverter(F3SourceTypes.class, F3SourceTypes::toType);
         cmd.setExecutionExceptionHandler(new ValidatorExceptionHandler(driver));
 
-        cmd.execute(args);
+        return cmd.execute(args);
     }
 
     private static class ValidatorExceptionHandler implements CommandLine.IExecutionExceptionHandler {

--- a/src/test/java/org/fcrepo/migration/validator/DriverIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/DriverIT.java
@@ -5,9 +5,11 @@
  */
 package org.fcrepo.migration.validator;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
-import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
@@ -20,16 +22,17 @@ import org.junit.Test;
  * Drives the command line entry point end to end so that argument binding, report selection, and the picocli
  * exception handling are all exercised.
  *
- * @author dbernstein
+ * @author Dan Field
  */
 public class DriverIT {
 
-    private static final File FIXTURES_BASE_DIR = new File("src/test/resources/test-object-validation");
-    private static final Path RESULTS_DIR = Path.of("target/test/results-driver-it");
+    private static final Path FIXTURES_BASE_DIR = Path.of("src", "test", "resources", "test-object-validation");
+    private static final Path RESULTS_DIR = Path.of("target", "test", "results-driver-it");
 
-    private static final File F3_DATASTREAMS_DIR = new File(FIXTURES_BASE_DIR, "valid/f3/datastreams");
-    private static final File F3_OBJECTS_DIR = new File(FIXTURES_BASE_DIR, "valid/f3/objects");
-    private static final File F6_OCFL_ROOT_DIR = new File(FIXTURES_BASE_DIR, "valid/f6/data/ocfl-root");
+    private static final Path F3_DATASTREAMS_DIR = FIXTURES_BASE_DIR.resolve("valid/f3/datastreams");
+    private static final Path F3_OBJECTS_DIR = FIXTURES_BASE_DIR.resolve("valid/f3/objects");
+    private static final Path F6_OCFL_ROOT_DIR = FIXTURES_BASE_DIR.resolve("valid/f6/data/ocfl-root");
+    private static final Path MISSING_DIR = FIXTURES_BASE_DIR.resolve("does-not-exist");
 
     @After
     public void teardown() {
@@ -40,8 +43,8 @@ public class DriverIT {
     public void testHtmlReport() {
         Driver.main(args("--report-type", "html", "--check-num-objects", "--checksum", "--debug"));
 
-        assertThat(RESULTS_DIR.resolve("html").resolve("index.html")).exists();
-        assertThat(RESULTS_DIR.resolve("json")).exists();
+        assertTrue("Expected an html summary report", Files.exists(RESULTS_DIR.resolve("html/index.html")));
+        assertTrue("Expected json results", Files.exists(RESULTS_DIR.resolve("json")));
     }
 
     @Test
@@ -49,8 +52,8 @@ public class DriverIT {
         Driver.main(args("--report-type", "csv"));
 
         final var csvDir = RESULTS_DIR.resolve("csv");
-        assertThat(csvDir).exists();
-        assertThat(summaryReports(csvDir, ".csv")).isPositive();
+        assertTrue("Expected a csv report directory", Files.exists(csvDir));
+        assertTrue("Expected at least one csv report", countReports(csvDir, ".csv") > 0);
     }
 
     @Test
@@ -58,8 +61,8 @@ public class DriverIT {
         Driver.main(args("--report-type", "tsv"));
 
         final var tsvDir = RESULTS_DIR.resolve("tsv");
-        assertThat(tsvDir).exists();
-        assertThat(summaryReports(tsvDir, ".tsv")).isPositive();
+        assertTrue("Expected a tsv report directory", Files.exists(tsvDir));
+        assertTrue("Expected at least one tsv report", countReports(tsvDir, ".tsv") > 0);
     }
 
     @Test
@@ -67,24 +70,26 @@ public class DriverIT {
         Driver.main(args("--report-type", "html", "--head-only", "--inactive-as-deleted", "--failure-only",
                          "--limit", "1", "--resume"));
 
-        assertThat(RESULTS_DIR.resolve("html").resolve("index.html")).exists();
-        assertThat(RESULTS_DIR.resolve("resume.txt")).exists();
+        assertTrue("Expected an html summary report", Files.exists(RESULTS_DIR.resolve("html/index.html")));
+        assertTrue("Expected a resume file", Files.exists(RESULTS_DIR.resolve("resume.txt")));
     }
 
     /**
-     * A missing objects directory fails inside {@code call()}, which routes through the driver's
-     * {@code IExecutionExceptionHandler}. No report should be produced.
+     * A missing objects directory fails inside call(), which routes through the driver's
+     * IExecutionExceptionHandler. No report should be produced.
      */
     @Test
     public void testExecutionExceptionIsHandled() {
-        final var exitCode = execute("--source-type", "akubra",
-                                     "--datastreams-dir", F3_DATASTREAMS_DIR.getAbsolutePath(),
-                                     "--objects-dir", new File(FIXTURES_BASE_DIR, "does-not-exist").getAbsolutePath(),
-                                     "--ocfl-root-dir", F6_OCFL_ROOT_DIR.getAbsolutePath(),
-                                     "--results-dir", RESULTS_DIR.toString());
+        final var exitCode = Driver.run(new String[] {
+            "--source-type", "akubra",
+            "--datastreams-dir", absolute(F3_DATASTREAMS_DIR),
+            "--objects-dir", absolute(MISSING_DIR),
+            "--ocfl-root-dir", absolute(F6_OCFL_ROOT_DIR),
+            "--results-dir", RESULTS_DIR.toString()
+        });
 
-        assertThat(exitCode).isNotZero();
-        assertThat(RESULTS_DIR.resolve("html").resolve("index.html")).doesNotExist();
+        assertNotEquals("Expected a non-zero exit code", 0, exitCode);
+        assertFalse("No report should be written", Files.exists(RESULTS_DIR.resolve("html/index.html")));
     }
 
     /**
@@ -92,27 +97,27 @@ public class DriverIT {
      */
     @Test
     public void testExecutionExceptionIsHandledWithDebug() {
-        final var exitCode = execute("--source-type", "akubra",
-                                     "--datastreams-dir", F3_DATASTREAMS_DIR.getAbsolutePath(),
-                                     "--objects-dir", new File(FIXTURES_BASE_DIR, "does-not-exist").getAbsolutePath(),
-                                     "--ocfl-root-dir", F6_OCFL_ROOT_DIR.getAbsolutePath(),
-                                     "--results-dir", RESULTS_DIR.toString(),
-                                     "--debug");
+        final var exitCode = Driver.run(new String[] {
+            "--source-type", "akubra",
+            "--datastreams-dir", absolute(F3_DATASTREAMS_DIR),
+            "--objects-dir", absolute(MISSING_DIR),
+            "--ocfl-root-dir", absolute(F6_OCFL_ROOT_DIR),
+            "--results-dir", RESULTS_DIR.toString(),
+            "--debug"
+        });
 
-        assertThat(exitCode).isNotZero();
+        assertNotEquals("Expected a non-zero exit code", 0, exitCode);
     }
 
     @Test
     public void testInvalidSourceTypeIsRejected() {
-        final var exitCode = execute("--source-type", "not-a-source-type",
-                                     "--ocfl-root-dir", F6_OCFL_ROOT_DIR.getAbsolutePath(),
-                                     "--results-dir", RESULTS_DIR.toString());
+        final var exitCode = Driver.run(new String[] {
+            "--source-type", "not-a-source-type",
+            "--ocfl-root-dir", absolute(F6_OCFL_ROOT_DIR),
+            "--results-dir", RESULTS_DIR.toString()
+        });
 
-        assertThat(exitCode).isNotZero();
-    }
-
-    private int execute(final String... args) {
-        return Driver.run(args);
+        assertNotEquals("Expected a non-zero exit code", 0, exitCode);
     }
 
     /**
@@ -121,9 +126,9 @@ public class DriverIT {
     private String[] args(final String... additional) {
         final var base = new String[] {
             "--source-type", "akubra",
-            "--datastreams-dir", F3_DATASTREAMS_DIR.getAbsolutePath(),
-            "--objects-dir", F3_OBJECTS_DIR.getAbsolutePath(),
-            "--ocfl-root-dir", F6_OCFL_ROOT_DIR.getAbsolutePath(),
+            "--datastreams-dir", absolute(F3_DATASTREAMS_DIR),
+            "--objects-dir", absolute(F3_OBJECTS_DIR),
+            "--ocfl-root-dir", absolute(F6_OCFL_ROOT_DIR),
             "--results-dir", RESULTS_DIR.toString(),
             "--threads", "1"
         };
@@ -131,10 +136,14 @@ public class DriverIT {
         return Stream.concat(Stream.of(base), Stream.of(additional)).toArray(String[]::new);
     }
 
-    private long summaryReports(final Path directory, final String extension) {
+    private String absolute(final Path path) {
+        return path.toAbsolutePath().toString();
+    }
+
+    private long countReports(final Path directory, final String extension) {
         try (var files = Files.list(directory)) {
             return files.filter(path -> path.getFileName().toString().endsWith(extension)).count();
-        } catch (final Exception e) {
+        } catch (final IOException e) {
             throw new IllegalStateException("Unable to list " + directory, e);
         }
     }

--- a/src/test/java/org/fcrepo/migration/validator/DriverIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/DriverIT.java
@@ -1,0 +1,141 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.migration.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Drives the command line entry point end to end so that argument binding, report selection, and the picocli
+ * exception handling are all exercised.
+ *
+ * @author dbernstein
+ */
+public class DriverIT {
+
+    private static final File FIXTURES_BASE_DIR = new File("src/test/resources/test-object-validation");
+    private static final Path RESULTS_DIR = Path.of("target/test/results-driver-it");
+
+    private static final File F3_DATASTREAMS_DIR = new File(FIXTURES_BASE_DIR, "valid/f3/datastreams");
+    private static final File F3_OBJECTS_DIR = new File(FIXTURES_BASE_DIR, "valid/f3/objects");
+    private static final File F6_OCFL_ROOT_DIR = new File(FIXTURES_BASE_DIR, "valid/f6/data/ocfl-root");
+
+    @After
+    public void teardown() {
+        FileUtils.deleteQuietly(RESULTS_DIR.toFile());
+    }
+
+    @Test
+    public void testHtmlReport() {
+        Driver.main(args("--report-type", "html", "--check-num-objects", "--checksum", "--debug"));
+
+        assertThat(RESULTS_DIR.resolve("html").resolve("index.html")).exists();
+        assertThat(RESULTS_DIR.resolve("json")).exists();
+    }
+
+    @Test
+    public void testCsvReport() {
+        Driver.main(args("--report-type", "csv"));
+
+        final var csvDir = RESULTS_DIR.resolve("csv");
+        assertThat(csvDir).exists();
+        assertThat(summaryReports(csvDir, ".csv")).isPositive();
+    }
+
+    @Test
+    public void testTsvReport() {
+        Driver.main(args("--report-type", "tsv"));
+
+        final var tsvDir = RESULTS_DIR.resolve("tsv");
+        assertThat(tsvDir).exists();
+        assertThat(summaryReports(tsvDir, ".tsv")).isPositive();
+    }
+
+    @Test
+    public void testHeadOnlyWithLimitAndResume() {
+        Driver.main(args("--report-type", "html", "--head-only", "--inactive-as-deleted", "--failure-only",
+                         "--limit", "1", "--resume"));
+
+        assertThat(RESULTS_DIR.resolve("html").resolve("index.html")).exists();
+        assertThat(RESULTS_DIR.resolve("resume.txt")).exists();
+    }
+
+    /**
+     * A missing objects directory fails inside {@code call()}, which routes through the driver's
+     * {@code IExecutionExceptionHandler}. No report should be produced.
+     */
+    @Test
+    public void testExecutionExceptionIsHandled() {
+        final var exitCode = execute("--source-type", "akubra",
+                                     "--datastreams-dir", F3_DATASTREAMS_DIR.getAbsolutePath(),
+                                     "--objects-dir", new File(FIXTURES_BASE_DIR, "does-not-exist").getAbsolutePath(),
+                                     "--ocfl-root-dir", F6_OCFL_ROOT_DIR.getAbsolutePath(),
+                                     "--results-dir", RESULTS_DIR.toString());
+
+        assertThat(exitCode).isNotZero();
+        assertThat(RESULTS_DIR.resolve("html").resolve("index.html")).doesNotExist();
+    }
+
+    /**
+     * Same as above, but with debug enabled so the handler also dumps the stack trace.
+     */
+    @Test
+    public void testExecutionExceptionIsHandledWithDebug() {
+        final var exitCode = execute("--source-type", "akubra",
+                                     "--datastreams-dir", F3_DATASTREAMS_DIR.getAbsolutePath(),
+                                     "--objects-dir", new File(FIXTURES_BASE_DIR, "does-not-exist").getAbsolutePath(),
+                                     "--ocfl-root-dir", F6_OCFL_ROOT_DIR.getAbsolutePath(),
+                                     "--results-dir", RESULTS_DIR.toString(),
+                                     "--debug");
+
+        assertThat(exitCode).isNotZero();
+    }
+
+    @Test
+    public void testInvalidSourceTypeIsRejected() {
+        final var exitCode = execute("--source-type", "not-a-source-type",
+                                     "--ocfl-root-dir", F6_OCFL_ROOT_DIR.getAbsolutePath(),
+                                     "--results-dir", RESULTS_DIR.toString());
+
+        assertThat(exitCode).isNotZero();
+    }
+
+    private int execute(final String... args) {
+        return Driver.run(args);
+    }
+
+    /**
+     * Builds a base argument list against the 'valid' akubra fixtures, appending any test specific arguments.
+     */
+    private String[] args(final String... additional) {
+        final var base = new String[] {
+            "--source-type", "akubra",
+            "--datastreams-dir", F3_DATASTREAMS_DIR.getAbsolutePath(),
+            "--objects-dir", F3_OBJECTS_DIR.getAbsolutePath(),
+            "--ocfl-root-dir", F6_OCFL_ROOT_DIR.getAbsolutePath(),
+            "--results-dir", RESULTS_DIR.toString(),
+            "--threads", "1"
+        };
+
+        return Stream.concat(Stream.of(base), Stream.of(additional)).toArray(String[]::new);
+    }
+
+    private long summaryReports(final Path directory, final String extension) {
+        try (var files = Files.list(directory)) {
+            return files.filter(path -> path.getFileName().toString().endsWith(extension)).count();
+        } catch (final Exception e) {
+            throw new IllegalStateException("Unable to list " + directory, e);
+        }
+    }
+}

--- a/src/test/java/org/fcrepo/migration/validator/api/ValidationConfigTest.java
+++ b/src/test/java/org/fcrepo/migration/validator/api/ValidationConfigTest.java
@@ -1,0 +1,75 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.migration.validator.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.fcrepo.migration.validator.impl.Fedora3ValidationConfig;
+import org.fcrepo.migration.validator.report.ReportType;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Covers the report directory resolution and accessors on the validation config.
+ *
+ * @author dbernstein
+ */
+public class ValidationConfigTest {
+
+    private static final Path RESULTS_DIR = Path.of("target", "test", "validation-config-test");
+
+    private Fedora3ValidationConfig config;
+
+    @Before
+    public void setup() {
+        config = new Fedora3ValidationConfig();
+        config.setResultsDirectory(RESULTS_DIR);
+        config.setOcflRepositoryRootDirectory(new File("target/test/ocfl-root"));
+    }
+
+    @Test
+    public void testReportDirectories() {
+        assertThat(config.getReportDirectory(ReportType.html)).isEqualTo(RESULTS_DIR.resolve("html"));
+        assertThat(config.getReportDirectory(ReportType.csv)).isEqualTo(RESULTS_DIR.resolve("csv"));
+        assertThat(config.getReportDirectory(ReportType.tsv)).isEqualTo(RESULTS_DIR.resolve("tsv"));
+        assertThat(config.getJsonOutputDirectory()).isEqualTo(RESULTS_DIR.resolve("json"));
+    }
+
+    @Test
+    public void testAccessors() {
+        final var indexDir = new File("target/test/index");
+        final var pidFile = new File("target/test/pids.txt");
+
+        config.setThreadCount(4);
+        config.setIndexDirectory(indexDir);
+        config.setFedora3Hostname("fedora.info");
+        config.setObjectsToValidate(pidFile);
+        config.setEnableChecksums(true);
+        config.setLimit(10);
+        config.setResume(true);
+        config.setFailureOnly(true);
+        config.setDeleteInactive(true);
+        config.setValidateHeadOnly(true);
+        config.setCheckNumObjects(true);
+
+        assertThat(config.getThreadCount()).isEqualTo(4);
+        assertThat(config.getIndexDirectory()).isEqualTo(indexDir);
+        assertThat(config.getFedora3Hostname()).isEqualTo("fedora.info");
+        assertThat(config.getObjectsToValidate()).isEqualTo(pidFile);
+        assertThat(config.enableChecksums()).isTrue();
+        assertThat(config.getLimit()).isEqualTo(10);
+        assertThat(config.isResume()).isTrue();
+        assertThat(config.isFailureOnly()).isTrue();
+        assertThat(config.isDeleteInactive()).isTrue();
+        assertThat(config.validateHeadOnly()).isTrue();
+        assertThat(config.checkNumObjects()).isTrue();
+        assertThat(config.getOcflRepositoryRootDirectory()).isEqualTo(new File("target/test/ocfl-root"));
+        assertThat(config.toString()).contains("threadCount");
+    }
+}

--- a/src/test/java/org/fcrepo/migration/validator/api/ValidationConfigTest.java
+++ b/src/test/java/org/fcrepo/migration/validator/api/ValidationConfigTest.java
@@ -5,9 +5,9 @@
  */
 package org.fcrepo.migration.validator.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.nio.file.Path;
 
 import org.fcrepo.migration.validator.impl.Fedora3ValidationConfig;
@@ -18,11 +18,12 @@ import org.junit.Test;
 /**
  * Covers the report directory resolution and accessors on the validation config.
  *
- * @author dbernstein
+ * @author Dan Field
  */
 public class ValidationConfigTest {
 
     private static final Path RESULTS_DIR = Path.of("target", "test", "validation-config-test");
+    private static final Path OCFL_ROOT_DIR = Path.of("target", "test", "ocfl-root");
 
     private Fedora3ValidationConfig config;
 
@@ -30,26 +31,26 @@ public class ValidationConfigTest {
     public void setup() {
         config = new Fedora3ValidationConfig();
         config.setResultsDirectory(RESULTS_DIR);
-        config.setOcflRepositoryRootDirectory(new File("target/test/ocfl-root"));
+        config.setOcflRepositoryRootDirectory(OCFL_ROOT_DIR.toFile());
     }
 
     @Test
     public void testReportDirectories() {
-        assertThat(config.getReportDirectory(ReportType.html)).isEqualTo(RESULTS_DIR.resolve("html"));
-        assertThat(config.getReportDirectory(ReportType.csv)).isEqualTo(RESULTS_DIR.resolve("csv"));
-        assertThat(config.getReportDirectory(ReportType.tsv)).isEqualTo(RESULTS_DIR.resolve("tsv"));
-        assertThat(config.getJsonOutputDirectory()).isEqualTo(RESULTS_DIR.resolve("json"));
+        assertEquals(RESULTS_DIR.resolve("html"), config.getReportDirectory(ReportType.html));
+        assertEquals(RESULTS_DIR.resolve("csv"), config.getReportDirectory(ReportType.csv));
+        assertEquals(RESULTS_DIR.resolve("tsv"), config.getReportDirectory(ReportType.tsv));
+        assertEquals(RESULTS_DIR.resolve("json"), config.getJsonOutputDirectory());
     }
 
     @Test
     public void testAccessors() {
-        final var indexDir = new File("target/test/index");
-        final var pidFile = new File("target/test/pids.txt");
+        final var indexDir = Path.of("target", "test", "index");
+        final var pidFile = Path.of("target", "test", "pids.txt");
 
         config.setThreadCount(4);
-        config.setIndexDirectory(indexDir);
+        config.setIndexDirectory(indexDir.toFile());
         config.setFedora3Hostname("fedora.info");
-        config.setObjectsToValidate(pidFile);
+        config.setObjectsToValidate(pidFile.toFile());
         config.setEnableChecksums(true);
         config.setLimit(10);
         config.setResume(true);
@@ -58,18 +59,18 @@ public class ValidationConfigTest {
         config.setValidateHeadOnly(true);
         config.setCheckNumObjects(true);
 
-        assertThat(config.getThreadCount()).isEqualTo(4);
-        assertThat(config.getIndexDirectory()).isEqualTo(indexDir);
-        assertThat(config.getFedora3Hostname()).isEqualTo("fedora.info");
-        assertThat(config.getObjectsToValidate()).isEqualTo(pidFile);
-        assertThat(config.enableChecksums()).isTrue();
-        assertThat(config.getLimit()).isEqualTo(10);
-        assertThat(config.isResume()).isTrue();
-        assertThat(config.isFailureOnly()).isTrue();
-        assertThat(config.isDeleteInactive()).isTrue();
-        assertThat(config.validateHeadOnly()).isTrue();
-        assertThat(config.checkNumObjects()).isTrue();
-        assertThat(config.getOcflRepositoryRootDirectory()).isEqualTo(new File("target/test/ocfl-root"));
-        assertThat(config.toString()).contains("threadCount");
+        assertEquals(4, config.getThreadCount());
+        assertEquals(indexDir.toFile(), config.getIndexDirectory());
+        assertEquals("fedora.info", config.getFedora3Hostname());
+        assertEquals(pidFile.toFile(), config.getObjectsToValidate());
+        assertTrue(config.enableChecksums());
+        assertEquals(10, config.getLimit());
+        assertTrue(config.isResume());
+        assertTrue(config.isFailureOnly());
+        assertTrue(config.isDeleteInactive());
+        assertTrue(config.validateHeadOnly());
+        assertTrue(config.checkNumObjects());
+        assertEquals(OCFL_ROOT_DIR.toFile(), config.getOcflRepositoryRootDirectory());
+        assertTrue("Expected the config to describe itself", config.toString().contains("threadCount"));
     }
 }

--- a/src/test/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelperIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelperIT.java
@@ -5,13 +5,17 @@
  */
 package org.fcrepo.migration.validator.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
 
 import io.ocfl.api.exception.OcflInputException;
 import org.apache.commons.io.FileUtils;
@@ -22,13 +26,13 @@ import org.junit.Test;
 /**
  * Covers the source-type specific wiring and pid file handling in {@link ApplicationConfigurationHelper}.
  *
- * @author mikejritter
+ * @author Dan Field
  */
 public class ApplicationConfigurationHelperIT {
 
-    private static final File FIXTURES_BASE_DIR = new File("src/test/resources/test-object-validation");
-    private static final File F3_OBJECTS_DIR = new File(FIXTURES_BASE_DIR, "valid/f3/objects");
-    private static final File F6_OCFL_ROOT_DIR = new File(FIXTURES_BASE_DIR, "valid/f6/data/ocfl-root");
+    private static final Path FIXTURES_BASE_DIR = Path.of("src", "test", "resources", "test-object-validation");
+    private static final Path F3_OBJECTS_DIR = FIXTURES_BASE_DIR.resolve("valid/f3/objects");
+    private static final Path F6_OCFL_ROOT_DIR = FIXTURES_BASE_DIR.resolve("valid/f6/data/ocfl-root");
 
     private Path workDir;
 
@@ -49,7 +53,7 @@ public class ApplicationConfigurationHelperIT {
         config.setSourceType(F3SourceTypes.EXPORTED);
         config.setExportedDirectory(exportedDir.toFile());
 
-        assertThat(new ApplicationConfigurationHelper(config).objectSource()).isNotNull();
+        assertNotNull(new ApplicationConfigurationHelper(config).objectSource());
     }
 
     @Test
@@ -58,7 +62,7 @@ public class ApplicationConfigurationHelperIT {
         config.setSourceType(F3SourceTypes.EXPORTED);
 
         final var helper = new ApplicationConfigurationHelper(config);
-        assertThatThrownBy(helper::objectSource).isInstanceOf(OcflInputException.class);
+        assertThrows(OcflInputException.class, helper::objectSource);
     }
 
     @Test
@@ -67,9 +71,9 @@ public class ApplicationConfigurationHelperIT {
         final var config = baseConfig();
         config.setSourceType(F3SourceTypes.LEGACY);
         config.setDatastreamsDirectory(datastreamsDir.toFile());
-        config.setObjectsDirectory(F3_OBJECTS_DIR);
+        config.setObjectsDirectory(F3_OBJECTS_DIR.toFile());
 
-        assertThat(new ApplicationConfigurationHelper(config).objectSource()).isNotNull();
+        assertNotNull(new ApplicationConfigurationHelper(config).objectSource());
     }
 
     @Test
@@ -78,27 +82,26 @@ public class ApplicationConfigurationHelperIT {
         final var config = baseConfig();
         config.setSourceType(F3SourceTypes.LEGACY);
         config.setDatastreamsDirectory(datastreamsDir.toFile());
-        config.setObjectsDirectory(new File(FIXTURES_BASE_DIR, "does-not-exist"));
+        config.setObjectsDirectory(FIXTURES_BASE_DIR.resolve("does-not-exist").toFile());
 
         final var helper = new ApplicationConfigurationHelper(config);
-        assertThatThrownBy(helper::objectSource).isInstanceOf(OcflInputException.class);
+        assertThrows(OcflInputException.class, helper::objectSource);
     }
 
     @Test
     public void testReadObjectsToValidate() throws IOException {
-        final var pidFile = workDir.resolve("pids.txt");
-        Files.write(pidFile, java.util.List.of("object-1", "object-2"));
+        final var pidFile = Files.write(workDir.resolve("pids.txt"), List.of("object-1", "object-2"));
 
         final var config = baseConfig();
         config.setObjectsToValidate(pidFile.toFile());
 
-        assertThat(new ApplicationConfigurationHelper(config).readObjectsToValidate())
-            .containsExactlyInAnyOrder("object-1", "object-2");
+        assertEquals(Set.of("object-1", "object-2"),
+                     new ApplicationConfigurationHelper(config).readObjectsToValidate());
     }
 
     @Test
     public void testReadObjectsToValidateWithoutPidFile() {
-        assertThat(new ApplicationConfigurationHelper(baseConfig()).readObjectsToValidate()).isEmpty();
+        assertTrue(new ApplicationConfigurationHelper(baseConfig()).readObjectsToValidate().isEmpty());
     }
 
     @Test
@@ -107,23 +110,22 @@ public class ApplicationConfigurationHelperIT {
         config.setObjectsToValidate(workDir.resolve("no-such-pid-file.txt").toFile());
 
         final var helper = new ApplicationConfigurationHelper(config);
-        assertThatThrownBy(helper::readObjectsToValidate)
-            .isInstanceOf(RuntimeException.class)
-            .hasCauseInstanceOf(IOException.class);
+        final var exception = assertThrows(RuntimeException.class, helper::readObjectsToValidate);
+        assertTrue("Expected the IOException to be wrapped", exception.getCause() instanceof IOException);
     }
 
     @Test
     public void testOcflComponents() {
         final var helper = new ApplicationConfigurationHelper(baseConfig());
 
-        assertThat(helper.ocflRepository()).isNotNull();
-        assertThat(helper.ocflObjectSessionFactory()).isNotNull();
-        assertThat(helper.getObjectValidationConfig()).isNotNull();
-        assertThat(helper.resumeManager()).isNotNull();
-        assertThat(helper.validationResultWriter()).isNotNull();
-        assertThat(helper.getThreadCount()).isEqualTo(1);
-        assertThat(helper.getLimit()).isZero();
-        assertThat(helper.checkNumObjects()).isFalse();
+        assertNotNull(helper.ocflRepository());
+        assertNotNull(helper.ocflObjectSessionFactory());
+        assertNotNull(helper.getObjectValidationConfig());
+        assertNotNull(helper.resumeManager());
+        assertNotNull(helper.validationResultWriter());
+        assertEquals(1, helper.getThreadCount());
+        assertEquals(0, helper.getLimit());
+        assertFalse(helper.checkNumObjects());
     }
 
     private Fedora3ValidationConfig baseConfig() {
@@ -131,7 +133,7 @@ public class ApplicationConfigurationHelperIT {
         config.setSourceType(F3SourceTypes.AKUBRA);
         config.setThreadCount(1);
         config.setResultsDirectory(workDir.resolve("results"));
-        config.setOcflRepositoryRootDirectory(F6_OCFL_ROOT_DIR);
+        config.setOcflRepositoryRootDirectory(F6_OCFL_ROOT_DIR.toFile());
         config.setDigestAlgorithm(F6DigestAlgorithm.sha512);
         return config;
     }

--- a/src/test/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelperIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/impl/ApplicationConfigurationHelperIT.java
@@ -1,0 +1,138 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.migration.validator.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.ocfl.api.exception.OcflInputException;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Covers the source-type specific wiring and pid file handling in {@link ApplicationConfigurationHelper}.
+ *
+ * @author mikejritter
+ */
+public class ApplicationConfigurationHelperIT {
+
+    private static final File FIXTURES_BASE_DIR = new File("src/test/resources/test-object-validation");
+    private static final File F3_OBJECTS_DIR = new File(FIXTURES_BASE_DIR, "valid/f3/objects");
+    private static final File F6_OCFL_ROOT_DIR = new File(FIXTURES_BASE_DIR, "valid/f6/data/ocfl-root");
+
+    private Path workDir;
+
+    @Before
+    public void setup() throws IOException {
+        workDir = Files.createTempDirectory("app-config-helper-it");
+    }
+
+    @After
+    public void teardown() {
+        FileUtils.deleteQuietly(workDir.toFile());
+    }
+
+    @Test
+    public void testExportedObjectSource() throws IOException {
+        final var exportedDir = Files.createDirectories(workDir.resolve("exported"));
+        final var config = baseConfig();
+        config.setSourceType(F3SourceTypes.EXPORTED);
+        config.setExportedDirectory(exportedDir.toFile());
+
+        assertThat(new ApplicationConfigurationHelper(config).objectSource()).isNotNull();
+    }
+
+    @Test
+    public void testExportedObjectSourceRequiresExportedDirectory() {
+        final var config = baseConfig();
+        config.setSourceType(F3SourceTypes.EXPORTED);
+
+        final var helper = new ApplicationConfigurationHelper(config);
+        assertThatThrownBy(helper::objectSource).isInstanceOf(OcflInputException.class);
+    }
+
+    @Test
+    public void testLegacyObjectSource() throws IOException {
+        final var datastreamsDir = Files.createDirectories(workDir.resolve("legacy-datastreams"));
+        final var config = baseConfig();
+        config.setSourceType(F3SourceTypes.LEGACY);
+        config.setDatastreamsDirectory(datastreamsDir.toFile());
+        config.setObjectsDirectory(F3_OBJECTS_DIR);
+
+        assertThat(new ApplicationConfigurationHelper(config).objectSource()).isNotNull();
+    }
+
+    @Test
+    public void testLegacyObjectSourceRequiresObjectsDirectoryToExist() throws IOException {
+        final var datastreamsDir = Files.createDirectories(workDir.resolve("legacy-datastreams-missing-objects"));
+        final var config = baseConfig();
+        config.setSourceType(F3SourceTypes.LEGACY);
+        config.setDatastreamsDirectory(datastreamsDir.toFile());
+        config.setObjectsDirectory(new File(FIXTURES_BASE_DIR, "does-not-exist"));
+
+        final var helper = new ApplicationConfigurationHelper(config);
+        assertThatThrownBy(helper::objectSource).isInstanceOf(OcflInputException.class);
+    }
+
+    @Test
+    public void testReadObjectsToValidate() throws IOException {
+        final var pidFile = workDir.resolve("pids.txt");
+        Files.write(pidFile, java.util.List.of("object-1", "object-2"));
+
+        final var config = baseConfig();
+        config.setObjectsToValidate(pidFile.toFile());
+
+        assertThat(new ApplicationConfigurationHelper(config).readObjectsToValidate())
+            .containsExactlyInAnyOrder("object-1", "object-2");
+    }
+
+    @Test
+    public void testReadObjectsToValidateWithoutPidFile() {
+        assertThat(new ApplicationConfigurationHelper(baseConfig()).readObjectsToValidate()).isEmpty();
+    }
+
+    @Test
+    public void testReadObjectsToValidateFailsOnMissingPidFile() {
+        final var config = baseConfig();
+        config.setObjectsToValidate(workDir.resolve("no-such-pid-file.txt").toFile());
+
+        final var helper = new ApplicationConfigurationHelper(config);
+        assertThatThrownBy(helper::readObjectsToValidate)
+            .isInstanceOf(RuntimeException.class)
+            .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void testOcflComponents() {
+        final var helper = new ApplicationConfigurationHelper(baseConfig());
+
+        assertThat(helper.ocflRepository()).isNotNull();
+        assertThat(helper.ocflObjectSessionFactory()).isNotNull();
+        assertThat(helper.getObjectValidationConfig()).isNotNull();
+        assertThat(helper.resumeManager()).isNotNull();
+        assertThat(helper.validationResultWriter()).isNotNull();
+        assertThat(helper.getThreadCount()).isEqualTo(1);
+        assertThat(helper.getLimit()).isZero();
+        assertThat(helper.checkNumObjects()).isFalse();
+    }
+
+    private Fedora3ValidationConfig baseConfig() {
+        final var config = new Fedora3ValidationConfig();
+        config.setSourceType(F3SourceTypes.AKUBRA);
+        config.setThreadCount(1);
+        config.setResultsDirectory(workDir.resolve("results"));
+        config.setOcflRepositoryRootDirectory(F6_OCFL_ROOT_DIR);
+        config.setDigestAlgorithm(F6DigestAlgorithm.sha512);
+        return config;
+    }
+}

--- a/src/test/java/org/fcrepo/migration/validator/impl/F3TypesTest.java
+++ b/src/test/java/org/fcrepo/migration/validator/impl/F3TypesTest.java
@@ -5,8 +5,6 @@
  */
 package org.fcrepo.migration.validator.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.fcrepo.migration.validator.impl.F3ControlGroup.EXTERNALLY_REFERENCED;
 import static org.fcrepo.migration.validator.impl.F3ControlGroup.INLINE_XML;
 import static org.fcrepo.migration.validator.impl.F3ControlGroup.MANAGED;
@@ -14,6 +12,11 @@ import static org.fcrepo.migration.validator.impl.F3ControlGroup.REDIRECT_REFERE
 import static org.fcrepo.migration.validator.impl.F3State.ACTIVE;
 import static org.fcrepo.migration.validator.impl.F3State.DELETED;
 import static org.fcrepo.migration.validator.impl.F3State.INACTIVE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.fcrepo.migration.ObjectProperty;
 import org.junit.Test;
@@ -21,37 +24,36 @@ import org.junit.Test;
 /**
  * Covers the string parsing of the Fedora 3 enum types.
  *
- * @author mikejritter
+ * @author Dan Field
  */
 public class F3TypesTest {
 
     @Test
     public void testControlGroupFromString() {
-        assertThat(F3ControlGroup.fromString("X")).isEqualTo(INLINE_XML);
-        assertThat(F3ControlGroup.fromString("m")).isEqualTo(MANAGED);
-        assertThat(F3ControlGroup.fromString("E")).isEqualTo(EXTERNALLY_REFERENCED);
-        assertThat(F3ControlGroup.fromString("r")).isEqualTo(REDIRECT_REFERENCED);
+        assertEquals(INLINE_XML, F3ControlGroup.fromString("X"));
+        assertEquals(MANAGED, F3ControlGroup.fromString("m"));
+        assertEquals(EXTERNALLY_REFERENCED, F3ControlGroup.fromString("E"));
+        assertEquals(REDIRECT_REFERENCED, F3ControlGroup.fromString("r"));
     }
 
     @Test
     public void testControlGroupRejectsUnknownValue() {
-        assertThatThrownBy(() -> F3ControlGroup.fromString("Z"))
-            .isInstanceOf(IllegalArgumentException.class);
+        assertThrows(IllegalArgumentException.class, () -> F3ControlGroup.fromString("Z"));
     }
 
     @Test
     public void testStateFromString() {
-        assertThat(F3State.fromString("A")).isEqualTo(ACTIVE);
-        assertThat(F3State.fromString("active")).isEqualTo(ACTIVE);
-        assertThat(F3State.fromString("D")).isEqualTo(DELETED);
-        assertThat(F3State.fromString("deleted")).isEqualTo(DELETED);
-        assertThat(F3State.fromString("I")).isEqualTo(INACTIVE);
-        assertThat(F3State.fromString("inactive")).isEqualTo(INACTIVE);
+        assertEquals(ACTIVE, F3State.fromString("A"));
+        assertEquals(ACTIVE, F3State.fromString("active"));
+        assertEquals(DELETED, F3State.fromString("D"));
+        assertEquals(DELETED, F3State.fromString("deleted"));
+        assertEquals(INACTIVE, F3State.fromString("I"));
+        assertEquals(INACTIVE, F3State.fromString("inactive"));
     }
 
     @Test
     public void testStateRejectsUnknownValue() {
-        assertThatThrownBy(() -> F3State.fromString("Z")).isInstanceOf(IllegalArgumentException.class);
+        assertThrows(IllegalArgumentException.class, () -> F3State.fromString("Z"));
     }
 
     @Test
@@ -68,34 +70,34 @@ public class F3TypesTest {
             }
         };
 
-        assertThat(F3State.fromProperty(property)).isEqualTo(DELETED);
+        assertEquals(DELETED, F3State.fromProperty(property));
     }
 
     @Test
     public void testStateIsDeleted() {
-        assertThat(DELETED.isDeleted(false)).isTrue();
-        assertThat(DELETED.isDeleted(true)).isTrue();
-        assertThat(INACTIVE.isDeleted(false)).isFalse();
-        assertThat(INACTIVE.isDeleted(true)).isTrue();
-        assertThat(ACTIVE.isDeleted(false)).isFalse();
-        assertThat(ACTIVE.isDeleted(true)).isFalse();
+        assertTrue(DELETED.isDeleted(false));
+        assertTrue(DELETED.isDeleted(true));
+        assertFalse(INACTIVE.isDeleted(false));
+        assertTrue(INACTIVE.isDeleted(true));
+        assertFalse(ACTIVE.isDeleted(false));
+        assertFalse(ACTIVE.isDeleted(true));
     }
 
     @Test
     public void testSourceTypeToType() {
-        assertThat(F3SourceTypes.toType("akubra")).isEqualTo(F3SourceTypes.AKUBRA);
-        assertThat(F3SourceTypes.toType("LEGACY")).isEqualTo(F3SourceTypes.LEGACY);
-        assertThat(F3SourceTypes.toType("Exported")).isEqualTo(F3SourceTypes.EXPORTED);
+        assertEquals(F3SourceTypes.AKUBRA, F3SourceTypes.toType("akubra"));
+        assertEquals(F3SourceTypes.LEGACY, F3SourceTypes.toType("LEGACY"));
+        assertEquals(F3SourceTypes.EXPORTED, F3SourceTypes.toType("Exported"));
     }
 
     @Test
     public void testSourceTypeRejectsUnknownValue() {
-        assertThatThrownBy(() -> F3SourceTypes.toType("nope")).isInstanceOf(IllegalArgumentException.class);
+        assertThrows(IllegalArgumentException.class, () -> F3SourceTypes.toType("nope"));
     }
 
     @Test
     public void testDigestAlgorithm() {
-        assertThat(F6DigestAlgorithm.sha256.getOcflUrn()).isEqualTo("urn:" + F6DigestAlgorithm.sha256.getName());
-        assertThat(F6DigestAlgorithm.sha512.hasher()).isNotNull();
+        assertEquals("urn:" + F6DigestAlgorithm.sha256.getName(), F6DigestAlgorithm.sha256.getOcflUrn());
+        assertNotNull(F6DigestAlgorithm.sha512.hasher());
     }
 }

--- a/src/test/java/org/fcrepo/migration/validator/impl/F3TypesTest.java
+++ b/src/test/java/org/fcrepo/migration/validator/impl/F3TypesTest.java
@@ -1,0 +1,101 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.migration.validator.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.fcrepo.migration.validator.impl.F3ControlGroup.EXTERNALLY_REFERENCED;
+import static org.fcrepo.migration.validator.impl.F3ControlGroup.INLINE_XML;
+import static org.fcrepo.migration.validator.impl.F3ControlGroup.MANAGED;
+import static org.fcrepo.migration.validator.impl.F3ControlGroup.REDIRECT_REFERENCED;
+import static org.fcrepo.migration.validator.impl.F3State.ACTIVE;
+import static org.fcrepo.migration.validator.impl.F3State.DELETED;
+import static org.fcrepo.migration.validator.impl.F3State.INACTIVE;
+
+import org.fcrepo.migration.ObjectProperty;
+import org.junit.Test;
+
+/**
+ * Covers the string parsing of the Fedora 3 enum types.
+ *
+ * @author mikejritter
+ */
+public class F3TypesTest {
+
+    @Test
+    public void testControlGroupFromString() {
+        assertThat(F3ControlGroup.fromString("X")).isEqualTo(INLINE_XML);
+        assertThat(F3ControlGroup.fromString("m")).isEqualTo(MANAGED);
+        assertThat(F3ControlGroup.fromString("E")).isEqualTo(EXTERNALLY_REFERENCED);
+        assertThat(F3ControlGroup.fromString("r")).isEqualTo(REDIRECT_REFERENCED);
+    }
+
+    @Test
+    public void testControlGroupRejectsUnknownValue() {
+        assertThatThrownBy(() -> F3ControlGroup.fromString("Z"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testStateFromString() {
+        assertThat(F3State.fromString("A")).isEqualTo(ACTIVE);
+        assertThat(F3State.fromString("active")).isEqualTo(ACTIVE);
+        assertThat(F3State.fromString("D")).isEqualTo(DELETED);
+        assertThat(F3State.fromString("deleted")).isEqualTo(DELETED);
+        assertThat(F3State.fromString("I")).isEqualTo(INACTIVE);
+        assertThat(F3State.fromString("inactive")).isEqualTo(INACTIVE);
+    }
+
+    @Test
+    public void testStateRejectsUnknownValue() {
+        assertThatThrownBy(() -> F3State.fromString("Z")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testStateFromProperty() {
+        final var property = new ObjectProperty() {
+            @Override
+            public String getName() {
+                return "info:fedora/fedora-system:def/model#state";
+            }
+
+            @Override
+            public String getValue() {
+                return "D";
+            }
+        };
+
+        assertThat(F3State.fromProperty(property)).isEqualTo(DELETED);
+    }
+
+    @Test
+    public void testStateIsDeleted() {
+        assertThat(DELETED.isDeleted(false)).isTrue();
+        assertThat(DELETED.isDeleted(true)).isTrue();
+        assertThat(INACTIVE.isDeleted(false)).isFalse();
+        assertThat(INACTIVE.isDeleted(true)).isTrue();
+        assertThat(ACTIVE.isDeleted(false)).isFalse();
+        assertThat(ACTIVE.isDeleted(true)).isFalse();
+    }
+
+    @Test
+    public void testSourceTypeToType() {
+        assertThat(F3SourceTypes.toType("akubra")).isEqualTo(F3SourceTypes.AKUBRA);
+        assertThat(F3SourceTypes.toType("LEGACY")).isEqualTo(F3SourceTypes.LEGACY);
+        assertThat(F3SourceTypes.toType("Exported")).isEqualTo(F3SourceTypes.EXPORTED);
+    }
+
+    @Test
+    public void testSourceTypeRejectsUnknownValue() {
+        assertThatThrownBy(() -> F3SourceTypes.toType("nope")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testDigestAlgorithm() {
+        assertThat(F6DigestAlgorithm.sha256.getOcflUrn()).isEqualTo("urn:" + F6DigestAlgorithm.sha256.getName());
+        assertThat(F6DigestAlgorithm.sha512.hasher()).isNotNull();
+    }
+}

--- a/src/test/java/org/fcrepo/migration/validator/impl/Fedora3ObjectValidatorIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/impl/Fedora3ObjectValidatorIT.java
@@ -1,0 +1,130 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.migration.validator.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.fcrepo.migration.validator.api.ValidationResult.Status.FAIL;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.OBJECT;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.OBJECT_READABLE;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.apache.commons.io.FileUtils;
+import org.fcrepo.migration.FedoraObjectProcessor;
+import org.fcrepo.migration.ObjectInfo;
+import org.fcrepo.migration.StreamingFedoraObjectHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies that an object which cannot be read is reported as a failed OBJECT_READABLE validation rather than
+ * aborting the run.
+ *
+ * @author dbernstein
+ */
+public class Fedora3ObjectValidatorIT {
+
+    private static final File FIXTURES_BASE_DIR = new File("src/test/resources/test-object-validation");
+    private static final File F6_OCFL_ROOT_DIR = new File(FIXTURES_BASE_DIR, "valid/f6/data/ocfl-root");
+
+    private Path workDir;
+    private ApplicationConfigurationHelper helper;
+
+    @Before
+    public void setup() throws IOException {
+        workDir = Files.createTempDirectory("f3-object-validator-it");
+
+        final var config = new Fedora3ValidationConfig();
+        config.setSourceType(F3SourceTypes.AKUBRA);
+        config.setThreadCount(1);
+        config.setResultsDirectory(workDir.resolve("results"));
+        config.setOcflRepositoryRootDirectory(F6_OCFL_ROOT_DIR);
+        config.setDigestAlgorithm(F6DigestAlgorithm.sha512);
+        helper = new ApplicationConfigurationHelper(config);
+    }
+
+    @After
+    public void teardown() {
+        FileUtils.deleteQuietly(workDir.toFile());
+    }
+
+    @Test
+    public void testUnreadableObjectIsReported() {
+        final var validator = new Fedora3ObjectValidator(helper.ocflObjectSessionFactory(),
+                                                         helper.getObjectValidationConfig());
+
+        final var results = validator.validate(new UnreadableObjectProcessor("info:fedora/unreadable"));
+
+        assertThat(results).hasSize(1);
+        final var result = results.get(0);
+        assertThat(result.getStatus()).isEqualTo(FAIL);
+        assertThat(result.getValidationLevel()).isEqualTo(OBJECT);
+        assertThat(result.getValidationType()).isEqualTo(OBJECT_READABLE);
+        assertThat(result.getDetails()).contains("Source object could not be read");
+    }
+
+    /**
+     * An object with no fedora URI falls back to a pid derived id, and still reports as unreadable.
+     */
+    @Test
+    public void testUnreadableObjectWithoutFedoraUri() {
+        final var validator = new Fedora3ObjectValidator(helper.ocflObjectSessionFactory(),
+                                                         helper.getObjectValidationConfig());
+
+        final var results = validator.validate(new UnreadableObjectProcessor(null));
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getSourceObjectId()).isEqualTo("info:fedora/unreadable-pid");
+    }
+
+    /**
+     * A processor whose FOXML cannot be parsed.
+     */
+    private static class UnreadableObjectProcessor implements FedoraObjectProcessor {
+
+        private final String fedoraUri;
+
+        UnreadableObjectProcessor(final String fedoraUri) {
+            this.fedoraUri = fedoraUri;
+        }
+
+        @Override
+        public ObjectInfo getObjectInfo() {
+            return new ObjectInfo() {
+                @Override
+                public String getPid() {
+                    return "unreadable-pid";
+                }
+
+                @Override
+                public String getFedoraURI() {
+                    return fedoraUri;
+                }
+
+                @Override
+                public Path getFoxmlPath() {
+                    return Path.of("does-not-exist.xml");
+                }
+            };
+        }
+
+        @Override
+        public void processObject(final StreamingFedoraObjectHandler handler) throws XMLStreamException {
+            throw new XMLStreamException("Unable to parse FOXML");
+        }
+
+        @Override
+        public void close() {
+            // nothing to close
+        }
+    }
+}

--- a/src/test/java/org/fcrepo/migration/validator/impl/Fedora3ObjectValidatorIT.java
+++ b/src/test/java/org/fcrepo/migration/validator/impl/Fedora3ObjectValidatorIT.java
@@ -5,12 +5,12 @@
  */
 package org.fcrepo.migration.validator.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.fcrepo.migration.validator.api.ValidationResult.Status.FAIL;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.OBJECT;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.OBJECT_READABLE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,12 +29,12 @@ import org.junit.Test;
  * Verifies that an object which cannot be read is reported as a failed OBJECT_READABLE validation rather than
  * aborting the run.
  *
- * @author dbernstein
+ * @author Dan Field
  */
 public class Fedora3ObjectValidatorIT {
 
-    private static final File FIXTURES_BASE_DIR = new File("src/test/resources/test-object-validation");
-    private static final File F6_OCFL_ROOT_DIR = new File(FIXTURES_BASE_DIR, "valid/f6/data/ocfl-root");
+    private static final Path FIXTURES_BASE_DIR = Path.of("src", "test", "resources", "test-object-validation");
+    private static final Path F6_OCFL_ROOT_DIR = FIXTURES_BASE_DIR.resolve("valid/f6/data/ocfl-root");
 
     private Path workDir;
     private ApplicationConfigurationHelper helper;
@@ -47,7 +47,7 @@ public class Fedora3ObjectValidatorIT {
         config.setSourceType(F3SourceTypes.AKUBRA);
         config.setThreadCount(1);
         config.setResultsDirectory(workDir.resolve("results"));
-        config.setOcflRepositoryRootDirectory(F6_OCFL_ROOT_DIR);
+        config.setOcflRepositoryRootDirectory(F6_OCFL_ROOT_DIR.toFile());
         config.setDigestAlgorithm(F6DigestAlgorithm.sha512);
         helper = new ApplicationConfigurationHelper(config);
     }
@@ -64,12 +64,13 @@ public class Fedora3ObjectValidatorIT {
 
         final var results = validator.validate(new UnreadableObjectProcessor("info:fedora/unreadable"));
 
-        assertThat(results).hasSize(1);
+        assertEquals(1, results.size());
         final var result = results.get(0);
-        assertThat(result.getStatus()).isEqualTo(FAIL);
-        assertThat(result.getValidationLevel()).isEqualTo(OBJECT);
-        assertThat(result.getValidationType()).isEqualTo(OBJECT_READABLE);
-        assertThat(result.getDetails()).contains("Source object could not be read");
+        assertEquals(FAIL, result.getStatus());
+        assertEquals(OBJECT, result.getValidationLevel());
+        assertEquals(OBJECT_READABLE, result.getValidationType());
+        assertTrue("Expected the read failure to be described",
+                   result.getDetails().contains("Source object could not be read"));
     }
 
     /**
@@ -82,8 +83,8 @@ public class Fedora3ObjectValidatorIT {
 
         final var results = validator.validate(new UnreadableObjectProcessor(null));
 
-        assertThat(results).hasSize(1);
-        assertThat(results.get(0).getSourceObjectId()).isEqualTo("info:fedora/unreadable-pid");
+        assertEquals(1, results.size());
+        assertEquals("info:fedora/unreadable-pid", results.get(0).getSourceObjectId());
     }
 
     /**

--- a/src/test/java/org/fcrepo/migration/validator/impl/ValidationResultIoTest.java
+++ b/src/test/java/org/fcrepo/migration/validator/impl/ValidationResultIoTest.java
@@ -5,12 +5,14 @@
  */
 package org.fcrepo.migration.validator.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.fcrepo.migration.validator.api.ValidationResult.Status.FAIL;
 import static org.fcrepo.migration.validator.api.ValidationResult.Status.OK;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.OBJECT;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.OBJECT_READABLE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -28,7 +30,7 @@ import org.junit.Test;
 /**
  * Round trips validation results through the filesystem writer and reader, and covers the results summary.
  *
- * @author awoods
+ * @author Dan Field
  */
 public class ValidationResultIoTest {
 
@@ -52,12 +54,12 @@ public class ValidationResultIoTest {
                                                 "all good");
         writer.write(List.of(result));
 
-        final var written = ValidationResultUtils.resolvePathToJsonResult(result, id -> id);
-        final var read = new FileSystemValidationResultReader().read(jsonRoot.resolve(written).toFile());
+        final var written = jsonRoot.resolve(ValidationResultUtils.resolvePathToJsonResult(result, id -> id));
+        final var read = new FileSystemValidationResultReader().read(written.toFile());
 
-        assertThat(read.getStatus()).isEqualTo(OK);
-        assertThat(read.getSourceObjectId()).isEqualTo("object-1");
-        assertThat(read.getDetails()).isEqualTo("all good");
+        assertEquals(OK, read.getStatus());
+        assertEquals("object-1", read.getSourceObjectId());
+        assertEquals("all good", read.getDetails());
     }
 
     @Test
@@ -70,8 +72,10 @@ public class ValidationResultIoTest {
                                                 "not good");
         writer.write(List.of(passed, failed));
 
-        assertThat(jsonRoot.resolve(ValidationResultUtils.resolvePathToJsonResult(passed, id -> id))).doesNotExist();
-        assertThat(jsonRoot.resolve(ValidationResultUtils.resolvePathToJsonResult(failed, id -> id))).exists();
+        assertFalse("Passing results should be skipped",
+                    Files.exists(jsonRoot.resolve(ValidationResultUtils.resolvePathToJsonResult(passed, id -> id))));
+        assertTrue("Failing results should be written",
+                   Files.exists(jsonRoot.resolve(ValidationResultUtils.resolvePathToJsonResult(failed, id -> id))));
     }
 
     @Test
@@ -79,7 +83,7 @@ public class ValidationResultIoTest {
         final var reader = new FileSystemValidationResultReader();
         final var missing = workDir.resolve("no-such-result.json").toFile();
 
-        assertThatThrownBy(() -> reader.read(missing)).isInstanceOf(RuntimeException.class);
+        assertThrows(RuntimeException.class, () -> reader.read(missing));
     }
 
     @Test
@@ -91,19 +95,18 @@ public class ValidationResultIoTest {
         summary.addObjectReport("object-1", objectReport);
         summary.addRepositoryReport(repositoryReport);
 
-        assertThat(summary.containsReport("object-1")).isTrue();
-        assertThat(summary.getObjectReports()).containsExactly(objectReport);
-        assertThat(summary.getRepositoryReport()).isEqualTo(repositoryReport);
-        assertThat(objectReport.getReportHref()).isEqualTo("object-1.html");
+        assertTrue(summary.containsReport("object-1"));
+        assertEquals(List.of(objectReport), List.copyOf(summary.getObjectReports()));
+        assertEquals(repositoryReport, summary.getRepositoryReport());
+        assertEquals("object-1.html", objectReport.getReportHref());
     }
 
     @Test
     public void testResultsSummaryRejectsDuplicateReport() {
         final var summary = new ValidationResultsSummary();
-        summary.addObjectReport("object-1", new ObjectReportSummary(true, "object-1", "object-1.html"));
+        final var report = new ObjectReportSummary(true, "object-1", "object-1.html");
+        summary.addObjectReport("object-1", report);
 
-        assertThatThrownBy(() -> summary.addObjectReport("object-1",
-                                                         new ObjectReportSummary(true, "object-1", "object-1.html")))
-            .isInstanceOf(IllegalArgumentException.class);
+        assertThrows(IllegalArgumentException.class, () -> summary.addObjectReport("object-1", report));
     }
 }

--- a/src/test/java/org/fcrepo/migration/validator/impl/ValidationResultIoTest.java
+++ b/src/test/java/org/fcrepo/migration/validator/impl/ValidationResultIoTest.java
@@ -1,0 +1,109 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.migration.validator.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.fcrepo.migration.validator.api.ValidationResult.Status.FAIL;
+import static org.fcrepo.migration.validator.api.ValidationResult.Status.OK;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.OBJECT;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.OBJECT_READABLE;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.fcrepo.migration.validator.api.ObjectReportSummary;
+import org.fcrepo.migration.validator.api.ValidationResult;
+import org.fcrepo.migration.validator.api.ValidationResultsSummary;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Round trips validation results through the filesystem writer and reader, and covers the results summary.
+ *
+ * @author awoods
+ */
+public class ValidationResultIoTest {
+
+    private Path workDir;
+
+    @Before
+    public void setup() throws IOException {
+        workDir = Files.createTempDirectory("validation-result-io-test");
+    }
+
+    @After
+    public void teardown() {
+        FileUtils.deleteQuietly(workDir.toFile());
+    }
+
+    @Test
+    public void testWriteThenRead() {
+        final var jsonRoot = workDir.resolve("json");
+        final var writer = new FileSystemValidationResultWriter(jsonRoot, false);
+        final var result = new ValidationResult(0, OK, OBJECT, OBJECT_READABLE, "object-1", "info:fedora/object-1",
+                                                "all good");
+        writer.write(List.of(result));
+
+        final var written = ValidationResultUtils.resolvePathToJsonResult(result, id -> id);
+        final var read = new FileSystemValidationResultReader().read(jsonRoot.resolve(written).toFile());
+
+        assertThat(read.getStatus()).isEqualTo(OK);
+        assertThat(read.getSourceObjectId()).isEqualTo("object-1");
+        assertThat(read.getDetails()).isEqualTo("all good");
+    }
+
+    @Test
+    public void testWriteFailureOnlySkipsPassingResults() {
+        final var jsonRoot = workDir.resolve("failure-only");
+        final var writer = new FileSystemValidationResultWriter(jsonRoot, true);
+        final var passed = new ValidationResult(0, OK, OBJECT, OBJECT_READABLE, "object-1", "info:fedora/object-1",
+                                                "all good");
+        final var failed = new ValidationResult(1, FAIL, OBJECT, OBJECT_READABLE, "object-1", "info:fedora/object-1",
+                                                "not good");
+        writer.write(List.of(passed, failed));
+
+        assertThat(jsonRoot.resolve(ValidationResultUtils.resolvePathToJsonResult(passed, id -> id))).doesNotExist();
+        assertThat(jsonRoot.resolve(ValidationResultUtils.resolvePathToJsonResult(failed, id -> id))).exists();
+    }
+
+    @Test
+    public void testReadFailsOnMissingFile() {
+        final var reader = new FileSystemValidationResultReader();
+        final var missing = workDir.resolve("no-such-result.json").toFile();
+
+        assertThatThrownBy(() -> reader.read(missing)).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    public void testResultsSummary() {
+        final var summary = new ValidationResultsSummary();
+        final var objectReport = new ObjectReportSummary(true, "object-1", "object-1.html");
+        final var repositoryReport = new ObjectReportSummary(false, "repository", "repository.html");
+
+        summary.addObjectReport("object-1", objectReport);
+        summary.addRepositoryReport(repositoryReport);
+
+        assertThat(summary.containsReport("object-1")).isTrue();
+        assertThat(summary.getObjectReports()).containsExactly(objectReport);
+        assertThat(summary.getRepositoryReport()).isEqualTo(repositoryReport);
+        assertThat(objectReport.getReportHref()).isEqualTo("object-1.html");
+    }
+
+    @Test
+    public void testResultsSummaryRejectsDuplicateReport() {
+        final var summary = new ValidationResultsSummary();
+        summary.addObjectReport("object-1", new ObjectReportSummary(true, "object-1", "object-1.html"));
+
+        assertThatThrownBy(() -> summary.addObjectReport("object-1",
+                                                         new ObjectReportSummary(true, "object-1", "object-1.html")))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/org/fcrepo/migration/validator/report/CsvReportHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/validator/report/CsvReportHandlerTest.java
@@ -5,14 +5,15 @@
  */
 package org.fcrepo.migration.validator.report;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.fcrepo.migration.validator.api.ValidationResult.Status.FAIL;
 import static org.fcrepo.migration.validator.api.ValidationResult.Status.OK;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.OBJECT;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.REPOSITORY;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.OBJECT_READABLE;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.REPOSITORY_RESOURCE_COUNT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -33,7 +34,7 @@ import org.junit.Test;
 /**
  * Covers the success and failure paths of the delimited report writer.
  *
- * @author mikejritter
+ * @author Dan Field
  */
 public class CsvReportHandlerTest {
 
@@ -63,18 +64,17 @@ public class CsvReportHandlerTest {
     public void testHtmlReportTypeIsRejected() {
         final var outputDir = workDir.resolve("html-rejected");
 
-        assertThatThrownBy(() -> new CsvReportHandler(outputDir, ReportType.html))
-            .isInstanceOf(IllegalArgumentException.class);
+        assertThrows(IllegalArgumentException.class, () -> new CsvReportHandler(outputDir, ReportType.html));
     }
 
     @Test
     public void testUncreatableOutputDirectoryIsRejected() throws IOException {
         // an existing regular file cannot also be a directory
-        final var file = Files.createFile(workDir.resolve("not-a-directory"));
+        final var outputDir = Files.createFile(workDir.resolve("not-a-directory")).resolve("output");
 
-        assertThatThrownBy(() -> new CsvReportHandler(file.resolve("output"), ReportType.csv))
-            .isInstanceOf(RuntimeException.class)
-            .hasCauseInstanceOf(IOException.class);
+        final var exception = assertThrows(RuntimeException.class,
+                                           () -> new CsvReportHandler(outputDir, ReportType.csv));
+        assertTrue("Expected the IOException to be wrapped", exception.getCause() instanceof IOException);
     }
 
     @Test
@@ -85,22 +85,21 @@ public class CsvReportHandlerTest {
 
         Files.createDirectories(outputDir.resolve(results.getEncodedObjectId() + ".csv"));
 
-        assertThatThrownBy(() -> handler.objectLevelReport(results))
-            .isInstanceOf(RuntimeException.class)
-            .hasCauseInstanceOf(IOException.class);
+        final var exception = assertThrows(RuntimeException.class, () -> handler.objectLevelReport(results));
+        assertTrue("Expected the IOException to be wrapped", exception.getCause() instanceof IOException);
     }
 
     @Test
     public void testValidationSummaryFailsWhenUnwritable() throws IOException {
         final var outputDir = workDir.resolve("summary-unwritable");
         final var handler = new CsvReportHandler(outputDir, ReportType.csv);
+        final var summary = new ValidationResultsSummary();
 
         final var date = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
         Files.createDirectories(outputDir.resolve("migration-validation-summary" + date + ".csv"));
 
-        assertThatThrownBy(() -> handler.validationSummary(new ValidationResultsSummary()))
-            .isInstanceOf(RuntimeException.class)
-            .hasCauseInstanceOf(IOException.class);
+        final var exception = assertThrows(RuntimeException.class, () -> handler.validationSummary(summary));
+        assertTrue("Expected the IOException to be wrapped", exception.getCause() instanceof IOException);
     }
 
     private void assertWritesAllReports(final ReportType reportType) {
@@ -108,19 +107,18 @@ public class CsvReportHandlerTest {
         final var handler = new CsvReportHandler(outputDir, reportType);
         handler.beginReport();
 
-        final var objectReport = handler.objectLevelReport(objectResults());
-        final var repositoryReport = handler.repositoryLevelReport(repositoryResults());
+        final var objectReport = Path.of(handler.objectLevelReport(objectResults()));
+        final var repositoryReport = Path.of(handler.repositoryLevelReport(repositoryResults()));
 
         final var summary = new ValidationResultsSummary();
-        summary.addObjectReport("object-1", new ObjectReportSummary(true, "object-1", objectReport));
-        final var summaryReport = handler.validationSummary(summary);
+        summary.addObjectReport("object-1", new ObjectReportSummary(true, "object-1", objectReport.toString()));
+        final var summaryReport = Path.of(handler.validationSummary(summary));
         handler.endReport();
 
-        assertThat(Path.of(objectReport)).exists();
-        assertThat(Path.of(repositoryReport)).exists();
-        assertThat(Path.of(summaryReport)).exists();
-        assertThat(Path.of(repositoryReport).getFileName().toString())
-            .isEqualTo("repository" + reportType.getExtension());
+        assertTrue("Expected an object report", Files.exists(objectReport));
+        assertTrue("Expected a repository report", Files.exists(repositoryReport));
+        assertTrue("Expected a summary report", Files.exists(summaryReport));
+        assertEquals("repository" + reportType.getExtension(), repositoryReport.getFileName().toString());
     }
 
     private ObjectValidationResults objectResults() {

--- a/src/test/java/org/fcrepo/migration/validator/report/CsvReportHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/validator/report/CsvReportHandlerTest.java
@@ -1,0 +1,136 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.migration.validator.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.fcrepo.migration.validator.api.ValidationResult.Status.FAIL;
+import static org.fcrepo.migration.validator.api.ValidationResult.Status.OK;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.OBJECT;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.REPOSITORY;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.OBJECT_READABLE;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.REPOSITORY_RESOURCE_COUNT;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.fcrepo.migration.validator.api.ObjectReportSummary;
+import org.fcrepo.migration.validator.api.ObjectValidationResults;
+import org.fcrepo.migration.validator.api.ValidationResult;
+import org.fcrepo.migration.validator.api.ValidationResultsSummary;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Covers the success and failure paths of the delimited report writer.
+ *
+ * @author mikejritter
+ */
+public class CsvReportHandlerTest {
+
+    private Path workDir;
+
+    @Before
+    public void setup() throws IOException {
+        workDir = Files.createTempDirectory("csv-report-handler-test");
+    }
+
+    @After
+    public void teardown() {
+        FileUtils.deleteQuietly(workDir.toFile());
+    }
+
+    @Test
+    public void testWritesAllReportsAsCsv() {
+        assertWritesAllReports(ReportType.csv);
+    }
+
+    @Test
+    public void testWritesAllReportsAsTsv() {
+        assertWritesAllReports(ReportType.tsv);
+    }
+
+    @Test
+    public void testHtmlReportTypeIsRejected() {
+        final var outputDir = workDir.resolve("html-rejected");
+
+        assertThatThrownBy(() -> new CsvReportHandler(outputDir, ReportType.html))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testUncreatableOutputDirectoryIsRejected() throws IOException {
+        // an existing regular file cannot also be a directory
+        final var file = Files.createFile(workDir.resolve("not-a-directory"));
+
+        assertThatThrownBy(() -> new CsvReportHandler(file.resolve("output"), ReportType.csv))
+            .isInstanceOf(RuntimeException.class)
+            .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void testObjectLevelReportFailsWhenUnwritable() throws IOException {
+        final var outputDir = workDir.resolve("object-unwritable");
+        final var handler = new CsvReportHandler(outputDir, ReportType.csv);
+        final var results = objectResults();
+
+        Files.createDirectories(outputDir.resolve(results.getEncodedObjectId() + ".csv"));
+
+        assertThatThrownBy(() -> handler.objectLevelReport(results))
+            .isInstanceOf(RuntimeException.class)
+            .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void testValidationSummaryFailsWhenUnwritable() throws IOException {
+        final var outputDir = workDir.resolve("summary-unwritable");
+        final var handler = new CsvReportHandler(outputDir, ReportType.csv);
+
+        final var date = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+        Files.createDirectories(outputDir.resolve("migration-validation-summary" + date + ".csv"));
+
+        assertThatThrownBy(() -> handler.validationSummary(new ValidationResultsSummary()))
+            .isInstanceOf(RuntimeException.class)
+            .hasCauseInstanceOf(IOException.class);
+    }
+
+    private void assertWritesAllReports(final ReportType reportType) {
+        final var outputDir = workDir.resolve(reportType.name());
+        final var handler = new CsvReportHandler(outputDir, reportType);
+        handler.beginReport();
+
+        final var objectReport = handler.objectLevelReport(objectResults());
+        final var repositoryReport = handler.repositoryLevelReport(repositoryResults());
+
+        final var summary = new ValidationResultsSummary();
+        summary.addObjectReport("object-1", new ObjectReportSummary(true, "object-1", objectReport));
+        final var summaryReport = handler.validationSummary(summary);
+        handler.endReport();
+
+        assertThat(Path.of(objectReport)).exists();
+        assertThat(Path.of(repositoryReport)).exists();
+        assertThat(Path.of(summaryReport)).exists();
+        assertThat(Path.of(repositoryReport).getFileName().toString())
+            .isEqualTo("repository" + reportType.getExtension());
+    }
+
+    private ObjectValidationResults objectResults() {
+        return new ObjectValidationResults(List.of(
+            new ValidationResult(0, OK, OBJECT, OBJECT_READABLE, "object-1", "info:fedora/object-1", "all good"),
+            new ValidationResult(1, FAIL, OBJECT, OBJECT_READABLE, "object-1", "info:fedora/object-1", "not good")));
+    }
+
+    private ObjectValidationResults repositoryResults() {
+        return new ObjectValidationResults(List.of(
+            new ValidationResult(0, OK, REPOSITORY, REPOSITORY_RESOURCE_COUNT, "counts match")));
+    }
+}

--- a/src/test/java/org/fcrepo/migration/validator/report/HtmlReportHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/validator/report/HtmlReportHandlerTest.java
@@ -5,14 +5,15 @@
  */
 package org.fcrepo.migration.validator.report;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.fcrepo.migration.validator.api.ValidationResult.Status.FAIL;
 import static org.fcrepo.migration.validator.api.ValidationResult.Status.OK;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.OBJECT;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.REPOSITORY;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.OBJECT_READABLE;
 import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.REPOSITORY_RESOURCE_COUNT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -31,7 +32,7 @@ import org.junit.Test;
 /**
  * Covers the success and failure paths of the HTML report writer.
  *
- * @author awoods
+ * @author Dan Field
  */
 public class HtmlReportHandlerTest {
 
@@ -62,10 +63,10 @@ public class HtmlReportHandlerTest {
         final var summaryReport = handler.validationSummary(summary);
         handler.endReport();
 
-        assertThat(summaryReport).isEqualTo("index.html");
-        assertThat(outputDir.resolve(objectReport)).exists();
-        assertThat(outputDir.resolve(repositoryReport)).exists();
-        assertThat(outputDir.resolve(summaryReport)).exists();
+        assertEquals("index.html", summaryReport);
+        assertTrue("Expected an object report", Files.exists(outputDir.resolve(objectReport)));
+        assertTrue("Expected a repository report", Files.exists(outputDir.resolve(repositoryReport)));
+        assertTrue("Expected a summary report", Files.exists(outputDir.resolve(summaryReport)));
     }
 
     @Test
@@ -76,32 +77,32 @@ public class HtmlReportHandlerTest {
         // a directory where the report file should go makes the FileWriter fail
         Files.createDirectories(outputDir.resolve(results.getEncodedObjectId() + ".html"));
 
-        assertThatThrownBy(() -> handler.objectLevelReport(results)).isInstanceOf(RuntimeException.class);
+        assertThrows(RuntimeException.class, () -> handler.objectLevelReport(results));
     }
 
     @Test
     public void testRepositoryLevelReportFailsWhenUnwritable() throws IOException {
         final var handler = new HtmlReportHandler(outputDir, 1);
+        final var results = repositoryResults();
         Files.createDirectories(outputDir.resolve("repository.html"));
 
-        assertThatThrownBy(() -> handler.repositoryLevelReport(repositoryResults()))
-            .isInstanceOf(RuntimeException.class);
+        assertThrows(RuntimeException.class, () -> handler.repositoryLevelReport(results));
     }
 
     @Test
     public void testValidationSummaryFailsWhenUnwritable() throws IOException {
         final var handler = new HtmlReportHandler(outputDir, 1);
+        final var summary = new ValidationResultsSummary();
         Files.createDirectories(outputDir.resolve("index.html"));
 
-        assertThatThrownBy(() -> handler.validationSummary(new ValidationResultsSummary()))
-            .isInstanceOf(RuntimeException.class);
+        assertThrows(RuntimeException.class, () -> handler.validationSummary(summary));
     }
 
     @Test
     public void testValidationSummaryRequiresSummary() {
         final var handler = new HtmlReportHandler(outputDir, 1);
 
-        assertThatThrownBy(() -> handler.validationSummary(null)).isInstanceOf(NullPointerException.class);
+        assertThrows(NullPointerException.class, () -> handler.validationSummary(null));
     }
 
     private ObjectValidationResults objectResults() {

--- a/src/test/java/org/fcrepo/migration/validator/report/HtmlReportHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/validator/report/HtmlReportHandlerTest.java
@@ -1,0 +1,117 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.migration.validator.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.fcrepo.migration.validator.api.ValidationResult.Status.FAIL;
+import static org.fcrepo.migration.validator.api.ValidationResult.Status.OK;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.OBJECT;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationLevel.REPOSITORY;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.OBJECT_READABLE;
+import static org.fcrepo.migration.validator.api.ValidationResult.ValidationType.REPOSITORY_RESOURCE_COUNT;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.fcrepo.migration.validator.api.ObjectReportSummary;
+import org.fcrepo.migration.validator.api.ObjectValidationResults;
+import org.fcrepo.migration.validator.api.ValidationResult;
+import org.fcrepo.migration.validator.api.ValidationResultsSummary;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Covers the success and failure paths of the HTML report writer.
+ *
+ * @author awoods
+ */
+public class HtmlReportHandlerTest {
+
+    private Path outputDir;
+
+    @Before
+    public void setup() throws IOException {
+        outputDir = Files.createTempDirectory("html-report-handler-test");
+    }
+
+    @After
+    public void teardown() {
+        FileUtils.deleteQuietly(outputDir.toFile());
+    }
+
+    @Test
+    public void testWritesAllReports() {
+        final var handler = new HtmlReportHandler(outputDir, 2);
+        handler.beginReport();
+
+        final var objectReport = handler.objectLevelReport(objectResults());
+        final var repositoryReport = handler.repositoryLevelReport(repositoryResults());
+
+        final var summary = new ValidationResultsSummary();
+        summary.addObjectReport("object-1", new ObjectReportSummary(true, "object-1", objectReport));
+        summary.addRepositoryReport(new ObjectReportSummary(false, "repository", repositoryReport));
+
+        final var summaryReport = handler.validationSummary(summary);
+        handler.endReport();
+
+        assertThat(summaryReport).isEqualTo("index.html");
+        assertThat(outputDir.resolve(objectReport)).exists();
+        assertThat(outputDir.resolve(repositoryReport)).exists();
+        assertThat(outputDir.resolve(summaryReport)).exists();
+    }
+
+    @Test
+    public void testObjectLevelReportFailsWhenUnwritable() throws IOException {
+        final var handler = new HtmlReportHandler(outputDir, 1);
+        final var results = objectResults();
+
+        // a directory where the report file should go makes the FileWriter fail
+        Files.createDirectories(outputDir.resolve(results.getEncodedObjectId() + ".html"));
+
+        assertThatThrownBy(() -> handler.objectLevelReport(results)).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    public void testRepositoryLevelReportFailsWhenUnwritable() throws IOException {
+        final var handler = new HtmlReportHandler(outputDir, 1);
+        Files.createDirectories(outputDir.resolve("repository.html"));
+
+        assertThatThrownBy(() -> handler.repositoryLevelReport(repositoryResults()))
+            .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    public void testValidationSummaryFailsWhenUnwritable() throws IOException {
+        final var handler = new HtmlReportHandler(outputDir, 1);
+        Files.createDirectories(outputDir.resolve("index.html"));
+
+        assertThatThrownBy(() -> handler.validationSummary(new ValidationResultsSummary()))
+            .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    public void testValidationSummaryRequiresSummary() {
+        final var handler = new HtmlReportHandler(outputDir, 1);
+
+        assertThatThrownBy(() -> handler.validationSummary(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    private ObjectValidationResults objectResults() {
+        return new ObjectValidationResults(List.of(
+            new ValidationResult(0, OK, OBJECT, OBJECT_READABLE, "object-1", "info:fedora/object-1", "all good"),
+            new ValidationResult(1, FAIL, OBJECT, OBJECT_READABLE, "object-1", "info:fedora/object-1", "not good")));
+    }
+
+    private ObjectValidationResults repositoryResults() {
+        return new ObjectValidationResults(List.of(
+            new ValidationResult(0, OK, REPOSITORY, REPOSITORY_RESOURCE_COUNT, "counts match")));
+    }
+}


### PR DESCRIPTION
Wires up JaCoCo + Codecov following the [fcrepo-camel](https://github.com/fcrepo-exts/fcrepo-camel) setup, and adds tests to bring coverage above the 90% target.

Line coverage: **86.06% → 96.07%** (instruction 86.14% → 95.06%).

## Codecov setup

- `codecov.yml` — project and patch targets at 90% with a 1% threshold, matching fcrepo-camel.
- `.github/workflows/build.yml` — the Maven step runs the JaCoCo agent/report goals, then uploads via `codecov/codecov-action@v5`. The upload is guarded to the Ubuntu + JDK 11 matrix cell; fcrepo-camel guards on OS only, but this repo's matrix also spans two JDKs, so the extra condition avoids duplicate uploads.
- `pom.xml` — `jacoco-maven-plugin` 0.8.12 with `prepare-agent`, `prepare-agent-integration`, and a `report` execution bound to `verify`, all writing to a single `target/jacoco.exec` so unit and integration coverage merge. Failsafe picks up the IT agent via `<argLine>${jacoco.agent.it.arg}</argLine>`.
- `README.md` — codecov badge.

Note: the workflow needs a `CODECOV_TOKEN` repository secret, and the repo needs to be added on codecov.io.

## Tests

22 new cases (78 total, all passing):

| File | Covers |
|---|---|
| `DriverIT` | The CLI end-to-end — html/csv/tsv reports, head-only + limit + resume, and both branches of the picocli exception handler. `Driver` was previously 0% covered. |
| `ApplicationConfigurationHelperIT` | `exported` and `legacy` source wiring, pid-file reading and its failure path, OCFL component construction |
| `Fedora3ObjectValidatorIT` | The unreadable-object path, via a fake `FedoraObjectProcessor` |
| `HtmlReportHandlerTest`, `CsvReportHandlerTest` | Report writing plus the IOException paths |
| `F3TypesTest`, `ValidationConfigTest`, `ValidationResultIoTest` | Enum parsing, config accessors, result write/read round-trip |

One production change: `Driver.main` now delegates to a package-private `run(String[])` that returns the exit code, so tests can assert on it. Behaviour is unchanged — `main` still does not call `System.exit`.

The 46 remaining uncovered lines are defensive catch blocks not reachable from a test (`InterruptedException` on task submission, executor shutdown timeouts, and similar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
